### PR TITLE
moved missing genotype location from run elements to samples

### DIFF
--- a/etc/schema.yaml
+++ b/etc/schema.yaml
@@ -47,7 +47,7 @@ run_elements:
     fastqc_report_r1: {         type: 'string',  required: False }
     fastqc_report_r2: {         type: 'string',  required: False }
 
-    reviewed: {                 type: 'string',  required: False, allowed: ['not reviewed', 'genotype missing', 'pass', 'fail'], default: 'not reviewed' }
+    reviewed: {                 type: 'string',  required: False, allowed: ['not reviewed', 'pass', 'fail'], default: 'not reviewed' }
     review_comments: {          type: 'string',  required: False }
     useable: {                  type: 'string',  required: False, allowed: ['not marked', 'yes', 'no' ], default: 'not marked' }
     useable_comments: {         type: 'multilinestring',  required: False }
@@ -93,7 +93,7 @@ samples:
     sample_contamination: {     type: 'dict',    required: False, schema: { freemix: {type: 'float'}, best_matching_samples: {type: 'dict'} } }
 
     #Events
-    reviewed: {                 type: 'string',  required: False, allowed: ['not reviewed', 'pass', 'fail'], default: 'not reviewed' }
+    reviewed: {                 type: 'string',  required: False, allowed: ['not reviewed', 'genotype missing', 'pass', 'fail'], default: 'not reviewed' }
     review_comments: {          type: 'string',  required: False }
     useable: {                  type: 'string',  required: False, allowed: ['not marked', 'yes', 'no' ], default: 'not marked' }
     useable_comments: {         type: 'multilinestring',  required: False }


### PR DESCRIPTION
Put 'genotype missing' option under run elements before - corrected this to be under samples