### PR TITLE
Stage timeline refactor

### DIFF
--- a/reporting_app/static/stage_timeline.js
+++ b/reporting_app/static/stage_timeline.js
@@ -1,0 +1,57 @@
+
+function _to_moment(str_date) {
+    return moment(str_date, 'DD_MM_YYYY_HH:mm:SS');
+}
+
+
+function _reformat(date) {
+    return _to_moment(date).format('YYYY-MM-DD HH:mm:ss');
+}
+
+
+function build_tooltip(stage) {
+    var t = '<div><b>' + stage.stage_name + '</b><br/>Started: ' + _reformat(stage.date_started) + '<br/>';
+    if (stage.date_finished) {
+        t += 'Finished: ' + _reformat(stage.date_finished) + '<br/>';
+        t += 'Exit status: ' + stage.exit_status + '<br/>';
+    }
+    t += '</div>';
+    return t;
+}
+
+
+function stage_timeline(div_id, proc) {
+    var stages = proc.stages.map(
+        function(s) {
+            var o = {
+                'start': _to_moment(s.date_started),
+                'style': 'display: block; overflow: visible',
+                'content': s.stage_name,
+                'title': build_tooltip(s)
+            };
+
+            if (s.date_finished) {
+                o['end'] = _to_moment(s.date_finished);
+                if (s.exit_status == 0) {
+                    o['style'] += '; background-color: #c2e0c6; border-color: #0e8a16';  // green
+                } else {
+                    o['style'] += '; background-color: #f7c6c7; border-color: #b60205';  // red
+                }
+            } else {
+                o['end'] = moment();
+            }
+            return o;
+        }
+    );
+
+    var items = new vis.DataSet(stages);
+    var startDate = _to_moment(proc._created);
+    var options = {
+            'tooltip': {
+            'followMouse': true,
+            'overflowMethod': 'cap'
+        }
+    };
+
+    var timeline = new vis.Timeline(document.getElementById(div_id), items, options);
+}

--- a/reporting_app/static/stage_timeline.js
+++ b/reporting_app/static/stage_timeline.js
@@ -11,47 +11,54 @@ function _reformat(date) {
 
 function build_tooltip(stage) {
     var t = '<div><b>' + stage.stage_name + '</b><br/>Started: ' + _reformat(stage.date_started) + '<br/>';
+
+    var stage_end;
     if (stage.date_finished) {
+        stage_end = _to_moment(stage.date_finished);
         t += 'Finished: ' + _reformat(stage.date_finished) + '<br/>';
         t += 'Exit status: ' + stage.exit_status + '<br/>';
+    } else {
+        stage_end = moment();
     }
-    t += '</div>';
+    t += 'Time elapsed: ' + moment.duration(stage_end.diff(_to_moment(stage.date_started))).humanize();
+    t += '<br/></div>';
     return t;
 }
 
 
 function stage_timeline(div_id, proc) {
-    var stages = proc.stages.map(
-        function(s) {
-            var o = {
-                'start': _to_moment(s.date_started),
-                'style': 'display: block; overflow: visible',
-                'content': s.stage_name,
-                'title': build_tooltip(s)
-            };
+    var stages;
 
-            if (s.date_finished) {
-                o['end'] = _to_moment(s.date_finished);
-                if (s.exit_status == 0) {
-                    o['style'] += '; background-color: #c2e0c6; border-color: #0e8a16';  // green
+    if (proc.stages === undefined) {
+        stages = []
+    } else {
+        stages = proc.stages.map(
+            function(s) {
+                var o = {
+                    'start': _to_moment(s.date_started),
+                    'style': 'display: block; overflow: visible',
+                    'content': s.stage_name,
+                    'title': build_tooltip(s)
+                };
+
+                if (s.date_finished) {
+                    o['end'] = _to_moment(s.date_finished);
+                    if (s.exit_status == 0) {
+                        o['style'] += '; background-color: #c2e0c6; border-color: #0e8a16';  // green
+                    } else {
+                        o['style'] += '; background-color: #f7c6c7; border-color: #b60205';  // red
+                    }
                 } else {
-                    o['style'] += '; background-color: #f7c6c7; border-color: #b60205';  // red
+                    o['end'] = moment();
                 }
-            } else {
-                o['end'] = moment();
+                return o;
             }
-            return o;
-        }
-    );
+        );
+    }
 
     var items = new vis.DataSet(stages);
     var startDate = _to_moment(proc._created);
-    var options = {
-            'tooltip': {
-            'followMouse': true,
-            'overflowMethod': 'cap'
-        }
-    };
+    var options = {'tooltip': {'followMouse': true, 'overflowMethod': 'cap'}};
 
     var timeline = new vis.Timeline(document.getElementById(div_id), items, options);
 }

--- a/reporting_app/templates/base.html
+++ b/reporting_app/templates/base.html
@@ -21,8 +21,7 @@
     <!-- Bootstrap/styling -->
     <link rel="stylesheet" href="{{ url_for('static', filename='stylesheets/bootstrap-3.3.6-dist/css/bootstrap.min.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='stylesheets/bootstrap-3.3.6-dist/css/bootstrap-theme.min.css') }}">
-    <!-- vis/styling -->
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/vis/4.16.1/vis.min.css" type="text/css" />
+
     <!-- reporting app/styling -->
     <link rel="stylesheet" href="{{ url_for('static', filename='stylesheets/reporting_app.css') }}">
 

--- a/reporting_app/templates/proc_report.html
+++ b/reporting_app/templates/proc_report.html
@@ -1,91 +1,75 @@
+{% macro proc_header() -%}
+<script src="//cdnjs.cloudflare.com/ajax/libs/vis/4.19.1/vis.min.js"></script>
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/vis/4.19.1/vis.min.css" type="text/css" />
+<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js"></script>
+<script src="/static/stage_timeline.js"></script>
+
+<style>
+    .vis-item .vis-item-overflow {
+        overflow: visible;
+    }
+
+    div.vis-tooltip {
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;  // override vis defaults back to bootstrap
+        background-color: #f9f9f9;
+    }
+</style>
+{%- endmacro %}
+
 
 {% macro proc_timeline(proc) -%}
 {# args:
     proc (dict) - analysis_driver_proc from the Rest API.
 #}
     <br/>
-    <ul>
-        <li>Started: {{ proc._created }}</li>
-        <li>Ended:
+    <div>
+        <div>Started: {{ proc._created }}</div>
+        <div>
             {% if proc.end_date %}
-            {{ proc.end_date }}
+            Ended: {{ proc.end_date }}
             {% else %}
-            running with pid: {{ proc.pid }}
+            Running with pid: {{ proc.pid }}
             {% endif %}
-        </li>
-        <li>
+        </div>
+        <div>
             Status:
             {% if proc.status %}
             {{ proc.status }}
             {% else %}
             inactive
             {% endif %}
-        </li>
-    </ul>
+        </div>
+    </div>
     <br/>
 
-    <div id="{{ proc.proc_id }}"></div>
+    <div id="timeline_{{ proc.proc_id }}"></div>
 
     <script type="text/javascript">
-        var container = document.getElementById('{{ proc.proc_id }}');
-        var stages = {{ proc.stages|list|safe }};
-        var stage_names = stages.map(function(p){
-            if (p.date_finished){
-                return {
-                    content: p.stage_name,
-                    'start': moment(p.date_started, "DD-MM-YYYY HH:mm:SS").format('YYYY-MM-DD HH:mm:SS'),
-                    'end': moment(p.date_finished, "DD-MM-YYYY HH:mm:SS").format('YYYY-MM-DD HH:mm:SS')
-                }
-            } else {
-                return {
-                    'start': moment(p.date_started, "DD-MM-YYYY HH:mm:SS").format('YYYY-MM-DD HH:mm:SS'),
-                    'style': "color: red; background-color: pink;"
-                }
-            }
-        });
-
-
-        var items = new vis.DataSet(stage_names);
-        startDate = (moment('{{ proc._created }}', "DD-MM-YYYY HH:mm:SS").format('YYYY-MM-DD HH:mm:SS'))
-        startMargin = moment(startDate).subtract(1, 'days')
-        endMargin = moment(startDate).add(6, 'days')
-        var options = {
-            min: startMargin,
-            max: endMargin
-        }
-        var timeline = new vis.Timeline(container, items, options);
+        stage_timeline("timeline_{{ proc.proc_id }}", {{ proc|safe }});
     </script>
     <br/>
 {%- endmacro %}
 
 
 {% macro proc_report(procs) -%}
-{# args:
-    procs (list[dict]) - analysis_driver_procs from the Rest API.
-#}
-    <script src="//cdnjs.cloudflare.com/ajax/libs/vis/4.16.1/vis.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js"></script>
+{# procs (list[dict]) - analysis_driver_procs from the Rest API. #}
 
-    <h2>
-        <a data-toggle="collapse" href="#analysis_driver_proc_tabs">
-            Analysis Driver processes
-        </a>
-    </h2>
-    <div id="analysis_driver_proc_tabs" class="tab-content collapse">
-        <p>Number of times processed: {{ procs|length }}</p>
-        {% if procs %}
-            <ul class="nav nav-tabs" id="analysis_driver_proc_ul">
-                <li class="nav active"><a data-target="#analysis_driver_proc_1_tab" data-toggle="tab">{{ procs[0]._created }}</a></li>
-                {% for proc in procs[1:] %}
-                    <li class="nav"><a data-target="#analysis_driver_proc_{{ loop.index + 1 }}_tab" data-toggle="tab">{{ proc._created }}</a></li>
-                {% endfor %}
-            </ul>
-
-            <div id="analysis_driver_proc_1_tab" class="tab-pane fade in active"> {{ proc_timeline(procs[0]) }} </div>
+<h2>Analysis Driver processes</h2>
+<div id="analysis_driver_proc_tabs" class="tab-content">
+    <p>Number of times processed: {{ procs|length }}</p>
+    {% if procs %}
+        <ul class="nav nav-tabs" id="analysis_driver_proc_ul">
+            <li class="nav active"><a data-target="#analysis_driver_proc_1_tab" data-toggle="tab">{{ procs[0]._created }}</a></li>
             {% for proc in procs[1:] %}
-                <div id="analysis_driver_proc_{{ loop.index + 1 }}_tab" class="tab-pane fade"> {{ proc_timeline(proc) }} </div>
+                <li class="nav"><a data-target="#analysis_driver_proc_{{ loop.index + 1 }}_tab" data-toggle="tab">{{ proc._created }}</a></li>
             {% endfor %}
-        {% endif %}
-    </div>
+        </ul>
+
+        <div id="analysis_driver_proc_1_tab" class="tab-pane fade in active">{{ proc_timeline(procs[0]) }}</div>
+        {% for proc in procs[1:] %}
+            <div id="analysis_driver_proc_{{ loop.index + 1 }}_tab" class="tab-pane fade">{{ proc_timeline(proc) }}</div>
+        {% endfor %}
+    {% endif %}
+</div>
 
 {%- endmacro %}

--- a/reporting_app/templates/proc_report.html
+++ b/reporting_app/templates/proc_report.html
@@ -45,7 +45,7 @@
     <div id="timeline_{{ proc.proc_id }}"></div>
 
     <script type="text/javascript">
-        stage_timeline("timeline_{{ proc.proc_id }}", {{ proc|safe }});
+        stage_timeline("timeline_{{ proc.proc_id }}", {{ proc|tojson }});
     </script>
     <br/>
 {%- endmacro %}
@@ -54,8 +54,8 @@
 {% macro proc_report(procs) -%}
 {# procs (list[dict]) - analysis_driver_procs from the Rest API. #}
 
-<h2>Analysis Driver processes</h2>
-<div id="analysis_driver_proc_tabs" class="tab-content">
+<h2><a data-toggle="collapse" data-target="#analysis_driver_proc_tabs">Analysis Driver processes</a></h2>
+<div id="analysis_driver_proc_tabs" class="tab-content collapse in">
     <p>Number of times processed: {{ procs|length }}</p>
     {% if procs %}
         <ul class="nav nav-tabs" id="analysis_driver_proc_ul">

--- a/reporting_app/templates/run_report.html
+++ b/reporting_app/templates/run_report.html
@@ -1,12 +1,14 @@
 {% extends 'tabbed_datatables.html' %}
 {% from 'datatable.html' import datatable %}
-{% from 'proc_report.html' import proc_report %}
+{% from 'proc_report.html' import proc_report, proc_header %}
 
+{% block head %}
+{{ proc_header() }}
+{{ super() }}
+{% endblock %}
 
 {% block content %}
-
 {{ datatable(lane_aggregation) }}
 {{ super() }}
 {{ proc_report(procs) }}
-
 {% endblock %}

--- a/reporting_app/templates/sample_report.html
+++ b/reporting_app/templates/sample_report.html
@@ -1,7 +1,12 @@
 {% extends 'untabbed_datatables.html' %}
-{% from 'proc_report.html' import proc_report %}
 {% from 'sample_status_report.html' import sample_status %}
 {% from 'datatable.html' import datatable %}
+{% from 'proc_report.html' import proc_report, proc_header %}
+
+{% block head %}
+{{ proc_header() }}
+{{ super() }}
+{% endblock %}
 
 {% block content %}
 {{ super() }}


### PR DESCRIPTION
- stages are now coloured depending on their exit status - zero -> green, nonzero -> red, not set -> blue
- non-completed stages now extend from start time to current time
- added a tooltip describing exact start/end times and exit statuses
- updated vis to 4.19.1, moment to 2.18.1

Closes #93.
