### PR TITLE
Docker image fixes

### DIFF
--- a/docker/reporting_app.sh
+++ b/docker/reporting_app.sh
@@ -8,8 +8,9 @@ then
 fi
 
 cd /opt/Reporting-App
-git fetch -a
+git pull
 git checkout $checkout_param
+/opt/python/bin/pip install -r requirements.txt
 
 /opt/database/mongodb-linux-x86_64-rhel70-3.4.1/bin/mongod > /opt/database/mongod.log &
 REPORTINGCONFIG=/opt/reporting.yaml /opt/python/bin/python bin/run_app.py rest_api


### PR DESCRIPTION
The Docker entry point should now pull all branches and do a `pip install -r`. Fixes #119. We will also need to rebuild the image on our compute.
