### PR TITLE
Use aggregated data

### DIFF
--- a/bin/retrigger_aggregation.py
+++ b/bin/retrigger_aggregation.py
@@ -19,10 +19,10 @@ def main():
 
     log_cfg.add_stdout_handler()
     c = Communicator((args.username, args.password), args.baseurl)
-    retrigger_aggregation(c)
+    retrigger_aggregation_run_element(c)
 
 
-def retrigger_aggregation(communicator, **filter):
+def retrigger_aggregation_run_element(communicator, **filter):
     all_runs = communicator.get_documents('runs', all_pages=True, **filter)
     app_logger.info('%s runs to process', len(all_runs))
     count = 0
@@ -31,6 +31,17 @@ def retrigger_aggregation(communicator, **filter):
         if count % 100 == 0:
             app_logger.info('%s runs processed', count)
         communicator.patch_entries('run_elements', {}, where={'run_id': r['run_id']})
+
+
+def retrigger_aggregation_project(communicator, **filter):
+    all_projects = communicator.get_documents('projects', all_pages=True, **filter)
+    app_logger.info('%s project to process', len(all_projects))
+    count = 0
+    for p in all_projects:
+        count += 1
+        if count % 100 == 0:
+            app_logger.info('%s projects processed', count)
+        communicator.patch_entry('projects', {}, 'project_id', p['project_id'])
 
 
 if __name__ == '__main__':

--- a/bin/retrigger_aggregation.py
+++ b/bin/retrigger_aggregation.py
@@ -22,8 +22,8 @@ def main():
     retrigger_aggregation(c)
 
 
-def retrigger_aggregation(communicator):
-    all_runs = communicator.get_documents('runs', all_pages=True)
+def retrigger_aggregation(communicator, **filter):
+    all_runs = communicator.get_documents('runs', all_pages=True, **filter)
     app_logger.info('%s runs to process', len(all_runs))
     count = 0
     for r in all_runs:

--- a/database_versioning/v0.15_to_v0.16.py
+++ b/database_versioning/v0.15_to_v0.16.py
@@ -14,7 +14,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from config import rest_config as rest_cfg
 from config import reporting_app_config as app_cfg
 
-from bin.retrigger_aggregation import retrigger_aggregation
+from bin.retrigger_aggregation import retrigger_aggregation_run_element
 
 
 if __name__ == '__main__':
@@ -73,6 +73,6 @@ if __name__ == '__main__':
 
     app_logger.info('%s samples updated' % counter)
     app_logger.info("Retrigger aggregation")
-    retrigger_aggregation(Communicator(auth=(args.username, args.password), baseurl=app_cfg['rest_api']))
+    retrigger_aggregation_run_element(Communicator(auth=(args.username, args.password), baseurl=app_cfg['rest_api']))
 
 

--- a/database_versioning/v0.16_to_v0.17.py
+++ b/database_versioning/v0.16_to_v0.17.py
@@ -7,9 +7,10 @@ import sys, os
 from egcg_core.app_logging import logging_default as log_cfg
 from egcg_core.exceptions import ConfigError
 from egcg_core.rest_communication import Communicator
-from pymongo import settings
+
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from rest_api import settings
 from config import reporting_app_config as app_cfg
 
 from bin.retrigger_aggregation import retrigger_aggregation

--- a/database_versioning/v0.16_to_v0.17.py
+++ b/database_versioning/v0.16_to_v0.17.py
@@ -1,0 +1,41 @@
+
+import argparse
+
+import datetime
+import sys, os
+
+from egcg_core.app_logging import logging_default as log_cfg
+from egcg_core.exceptions import ConfigError
+from egcg_core.rest_communication import Communicator
+from pymongo import settings
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from config import reporting_app_config as app_cfg
+
+from bin.retrigger_aggregation import retrigger_aggregation
+
+
+if __name__ == '__main__':
+
+    log_cfg.add_stdout_handler()
+    app_logger = log_cfg.get_logger('migration_v0.16_v0.17')
+
+    a = argparse.ArgumentParser()
+    a.add_argument('--username', required=True)
+    a.add_argument('--password', required=True)
+    args = a.parse_args()
+
+    # check the config is set
+    if not app_cfg or 'rest_api' not in app_cfg:
+        raise ConfigError('Configuration file was not set or is missing values')
+
+    two_month_ago = datetime.datetime.now() - datetime.timedelta(days=60)
+
+    app_logger.info("Retrigger aggregation")
+    # only retrigger aggregation on recent runs
+    retrigger_aggregation(
+        Communicator(auth=(args.username, args.password), baseurl=app_cfg['rest_api']),
+        where={'_created': {'$gte': two_month_ago.strftime(settings.DATE_FORMAT)}}
+    )
+
+

--- a/database_versioning/v0.16_to_v0.17.py
+++ b/database_versioning/v0.16_to_v0.17.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     if not app_cfg or 'rest_api' not in app_cfg:
         raise ConfigError('Configuration file was not set or is missing values')
 
-    two_month_ago = datetime.datetime.now() - datetime.timedelta(days=60)
+    two_month_ago = datetime.datetime.now() - datetime.timedelta(days=90)
 
     app_logger.info("Retrigger aggregation")
     # only retrigger aggregation on recent runs

--- a/database_versioning/v0.16_to_v0.17.py
+++ b/database_versioning/v0.16_to_v0.17.py
@@ -13,8 +13,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from rest_api import settings
 from config import reporting_app_config as app_cfg
 
-from bin.retrigger_aggregation import retrigger_aggregation
-
+from bin.retrigger_aggregation import retrigger_aggregation_run_element, retrigger_aggregation_project
 
 if __name__ == '__main__':
 
@@ -34,9 +33,13 @@ if __name__ == '__main__':
 
     app_logger.info("Retrigger aggregation")
     # only retrigger aggregation on recent runs
-    retrigger_aggregation(
-        Communicator(auth=(args.username, args.password), baseurl=app_cfg['rest_api']),
-        where={'_created': {'$gte': two_month_ago.strftime(settings.DATE_FORMAT)}}
-    )
+    c = Communicator(auth=(args.username, args.password), baseurl=app_cfg['rest_api'])
+
+    # retrigger_aggregation_run_element(
+    #     c,
+    #     where={'_created': {'$gte': two_month_ago.strftime(settings.DATE_FORMAT)}}
+    # )
+
+    retrigger_aggregation_project(c)
 
 

--- a/database_versioning/v0.16_to_v0.17.py
+++ b/database_versioning/v0.16_to_v0.17.py
@@ -35,10 +35,10 @@ if __name__ == '__main__':
     # only retrigger aggregation on recent runs
     c = Communicator(auth=(args.username, args.password), baseurl=app_cfg['rest_api'])
 
-    # retrigger_aggregation_run_element(
-    #     c,
-    #     where={'_created': {'$gte': two_month_ago.strftime(settings.DATE_FORMAT)}}
-    # )
+    retrigger_aggregation_run_element(
+        c,
+        where={'_created': {'$gte': two_month_ago.strftime(settings.DATE_FORMAT)}}
+    )
 
     retrigger_aggregation_project(c)
 

--- a/etc/column_mappings.yaml
+++ b/etc/column_mappings.yaml
@@ -39,9 +39,9 @@ column_def:
     evenness:                 { data: 'coverage.evenness',                    title: '% Evenness',               fmt: { type: 'ratio_percentage', min: .8 } }
     mismatching_snps:         { data: 'genotype_validation.mismatching_snps', title: 'Mismatching snps' ,                                              visible: 'false'}
     nb_quoted_samples:        { data: 'nb_quoted_samples',                    title: 'Quoted Samples' ,          class_name: 'text-center sum' }
-    nb_samples_delivered:     { data: 'aggregated.nb_samples_delivered',      title: 'Samples Delivered' }
-    nb_samples:               { data: 'aggregated.nb_samples',                title: 'Nb of Samples' }
-    nb_samples_reviewed:      { data: 'aggregated.nb_samples_reviewed',       title: 'Samples Reviewed' }
+    nb_samples_delivered:     { data: 'aggregated.samples_delivered',         title: 'Samples Delivered',        fmt: {link_format_function: 'count_entities', link: '/sample/' }, class_name: 'text-center sum' }
+    nb_samples:               { data: 'aggregated.samples',                   title: 'Samples',                  fmt: {link_format_function: 'count_entities', link: '/sample/' }, class_name: 'text-center sum' }
+    nb_samples_reviewed:      { data: 'aggregated.samples_reviewed',          title: 'Samples Reviewed',         fmt: {link_format_function: 'count_entities', link: '/sample/' }, class_name: 'text-center sum' }
     nb_sample_submission:     { data: 'sample_submission',                    title: 'Sample Submission' ,       fmt: {link_format_function: 'count_entities', link: '/sample/' }, class_name: 'text-center sum' }
     nb_sample_qc:             { data: 'sample_qc',                            title: 'Sample QC' ,               fmt: {link_format_function: 'count_entities', link: '/sample/' }, class_name: 'text-center sum' }
     nb_library_queue:         { data: 'library_queue',                        title: 'Library Queue' ,           fmt: {link_format_function: 'count_entities', link: '/sample/' }, class_name: 'text-center sum' }

--- a/etc/column_mappings.yaml
+++ b/etc/column_mappings.yaml
@@ -15,22 +15,22 @@
 column_def:
     bam_file_reads:           { data: 'bam_file_reads',                       title: 'Initial reads in bam',     fmt: { type: 'int' } }
     barcode:                  { data: 'barcode',                              title: 'Barcode' }
-    clean_pc_q30:             { data: 'clean_pc_q30',                         title: '% Q30 - cleaned',          fmt: { type: 'percentage', min: 75 }, visible: 'false'  }
-    clean_pc_q30_r1:          { data: 'clean_pc_q30_r1',                      title: '% Q30 R1 - cleaned',       fmt: { type: 'percentage', min: 75 }, visible: 'false' }
-    clean_pc_q30_r2:          { data: 'clean_pc_q30_r2',                      title: '% Q30 R2 - cleaned',       fmt: { type: 'percentage', min: 75 }, visible: 'false' }
-    clean_yield_in_gb:        { data: 'clean_yield_in_gb',                    title: 'Yield (Gb - cleaned)',     fmt: { type: 'float' } }
-    clean_yield_q30_in_gb:    { data: 'clean_yield_q30_in_gb',                title: 'Yield Q30 (Gb - cleaned)', fmt: { type: 'float',  min: 770 } }
-    clean_yield_q30:          { data: 'clean_yield_q30',                      title: 'Yield Q30 (Gb - cleaned)', fmt: { type: 'float' } }
+    clean_pc_q30:             { data: 'aggregated.clean_pc_q30',              title: '% Q30 - cleaned',          fmt: { type: 'percentage', min: 75 }, visible: 'false'  }
+    clean_pc_q30_r1:          { data: 'aggregated.clean_pc_q30_r1',           title: '% Q30 R1 - cleaned',       fmt: { type: 'percentage', min: 75 }, visible: 'false' }
+    clean_pc_q30_r2:          { data: 'aggregated.clean_pc_q30_r2',           title: '% Q30 R2 - cleaned',       fmt: { type: 'percentage', min: 75 }, visible: 'false' }
+    clean_yield_in_gb:        { data: 'aggregated.clean_yield_in_gb',         title: 'Yield (Gb - cleaned)',     fmt: { type: 'float' } }
+    clean_yield_q30_in_gb:    { data: 'aggregated.clean_yield_q30_in_gb',     title: 'Yield Q30 (Gb - cleaned)', fmt: { type: 'float' } }
     _created:                 { data: '_created',                             title: 'Created' }
-    cv:                       { data: 'cv',                                   title: 'Coefficient of variance',  fmt: { type: 'float' } }
+    cv:                       { data: 'aggregated.cv',                        title: 'Coefficient of variance',  fmt: { type: 'float' }, visible: 'false' }
     delivered:                { data: 'delivered',                            title: 'Delivered'}
     duplicate_reads:          { data: 'duplicate_reads',                      title: '# duplicate reads',        fmt: { type: 'int' },    visible: 'false',         }
     lane_pc_optical_dups:     { data: 'lane_pc_optical_dups',                 title: 'Estimated dupl rate',      fmt: { type: 'float', max: 20 } }
     lane_number:              { data: 'lane_number',                          title: 'Lane' }
     library_id:               { data: 'library_id',                           title: 'Library ID' }
     library_type:             { data: 'library_type',                         title: 'Library',                                                        visible: 'false' }
-    genotype_match:           { data: 'genotype_match',                       title: 'Genotype'   }
-    mapped_reads:             { data: 'mapped_reads',                         title: '# mapped reads',           fmt: { type: 'int' },    visible: 'false',  }
+    genotype_match:           { data: 'aggregated.genotype_match',            title: 'Genotype'   }
+    mean_insert_size:         { data: 'mapping_metrics.mean_insert_size',     title: 'Avg Insert Size',           fmt: { type: 'float' }, visible: 'false' }
+    mapped_reads:             { data: 'mapped_reads',                         title: '# mapped reads',           fmt: { type: 'int' },    visible: 'false'  }
     matching_snps:            { data: 'genotype_validation.matching_snps',    title: 'Matching snps' ,                                                 visible: 'false'}
     median_coverage:          { data: 'median_coverage',                      title: 'Median coverage',          fmt: { type: 'float', min: {field: 'Coverage (X)', default: 30} } }
     mean_coverage:            { data: 'coverage.mean',                        title: 'Mean coverage',            fmt: { type: 'float', min: {field: 'Coverage (X)', default: 30} } }
@@ -39,9 +39,9 @@ column_def:
     evenness:                 { data: 'coverage.evenness',                    title: '% Evenness',               fmt: { type: 'ratio_percentage', min: .8 } }
     mismatching_snps:         { data: 'genotype_validation.mismatching_snps', title: 'Mismatching snps' ,                                              visible: 'false'}
     nb_quoted_samples:        { data: 'nb_quoted_samples',                    title: 'Quoted Samples' ,          class_name: 'text-center sum' }
-    nb_samples_delivered:     { data: 'nb_samples_delivered',                 title: 'Samples Delivered' }
-    nb_samples:               { data: 'nb_samples',                           title: 'Nb of Samples' }
-    nb_samples_reviewed:      { data: 'nb_samples_reviewed',                  title: 'Samples Reviewed' }
+    nb_samples_delivered:     { data: 'aggregated.nb_samples_delivered',      title: 'Samples Delivered' }
+    nb_samples:               { data: 'aggregated.nb_samples',                title: 'Nb of Samples' }
+    nb_samples_reviewed:      { data: 'aggregated.nb_samples_reviewed',       title: 'Samples Reviewed' }
     nb_sample_submission:     { data: 'sample_submission',                    title: 'Sample Submission' ,       fmt: {link_format_function: 'count_entities', link: '/sample/' }, class_name: 'text-center sum' }
     nb_sample_qc:             { data: 'sample_qc',                            title: 'Sample QC' ,               fmt: {link_format_function: 'count_entities', link: '/sample/' }, class_name: 'text-center sum' }
     nb_library_queue:         { data: 'library_queue',                        title: 'Library Queue' ,           fmt: {link_format_function: 'count_entities', link: '/sample/' }, class_name: 'text-center sum' }
@@ -59,38 +59,39 @@ column_def:
     no_call_seq:              { data: 'genotype_validation.no_call_seq',      title: 'No-call (seq)' ,                                                 visible: 'false'}
     called_gender:            { data: 'called_gender',                        title: 'Called Gender' ,                                                 visible: 'false'}
     provided_gender:          { data: 'provided_gender',                      title: 'Provided Gender',                                                visible: 'false' }
-    gender_match:             { data: 'gender_match',                         title: 'Gender' }
+    gender_match:             { data: 'aggregated.gender_match',              title: 'Gender' }
     passing_filter_reads:     { data: 'passing_filter_reads',                 title: 'Passing-filter reads',     fmt: { type: 'int' } }
-    pc_adapter:               { data: 'pc_adapter',                           title: '% Adapter',                fmt: { type: 'percentage', max: 5 } }
+    pc_adaptor:               { data: 'aggregated.pc_adaptor',                title: '% Adapter',                fmt: { type: 'percentage', max: 5 } }
     pc_callable:              { data: 'pc_callable',                          title: '% callable',               fmt: { type: 'percentage', min: 70 }, visible: 'false' }
-    pc_duplicate_reads:       { data: 'pc_duplicate_reads',                   title: '% duplicate reads',        fmt: { type: 'percentage', max: 35 } }
-    pc_mapped_reads:          { data: 'pc_mapped_reads',                      title: '% mapped reads',           fmt: { type: 'percentage', min: 90 } }
-    pc_pass_filter:           { data: 'pc_pass_filter',                       title: '% Pass filter',            fmt: { type: 'percentage' } }
-    pc_properly_mapped_reads: { data: 'pc_properly_mapped_reads',             title: '% properly mapped reads',  fmt: { type: 'percentage' }, visible: 'false' }
-    pc_q30:                   { data: 'pc_q30',                               title: '%Q30',                     fmt: { type: 'percentage',  min: 75 } }
-    pc_q30_r1:                { data: 'pc_q30_r1',                            title: '%Q30 R1',                  fmt: { type: 'percentage',  min: 75 } }
-    pc_q30_r2:                { data: 'pc_q30_r2',                            title: '%Q30 R2',                  fmt: { type: 'percentage',  min: 75 } }
+    pc_duplicate_reads:       { data: 'aggregated.pc_duplicate_reads',        title: '% duplicate reads',        fmt: { type: 'percentage', max: 35 } }
+    pc_opt_duplicate_reads:   { data: 'aggregated.pc_opt_duplicate_reads',    title: '% opt duplicate reads',    fmt: { type: 'percentage', max: 20 } }
+    pc_mapped_reads:          { data: 'aggregated.pc_mapped_reads',           title: '% mapped reads',           fmt: { type: 'percentage', min: 90 } }
+    pc_pass_filter:           { data: 'aggregated.pc_pass_filter',            title: '% Pass filter',            fmt: { type: 'percentage' } }
+    pc_properly_mapped_reads: { data: 'aggregated.pc_properly_mapped_reads',  title: '% properly mapped reads',  fmt: { type: 'percentage' }, visible: 'false' }
+    pc_q30:                   { data: 'aggregated.pc_q30',                    title: '%Q30',                     fmt: { type: 'percentage',  min: 75 } }
+    pc_q30_r1:                { data: 'aggregated.pc_q30_r1',                 title: '%Q30 R1',                  fmt: { type: 'percentage',  min: 75 } }
+    pc_q30_r2:                { data: 'aggregated.pc_q30_r2',                 title: '%Q30 R2',                  fmt: { type: 'percentage',  min: 75 } }
     pc_reads_in_lane:         { data: 'pc_reads_in_lane',                     title: '% Reads in lane',          fmt: { type: 'percentage'} }
-    proc_status:              { data: 'proc_status',                          title: 'Processing Status' }
+    proc_status:              { data: 'aggregated.most_recent_proc.status',   title: 'Processing Status' }
     project_id:               { data: 'project_id',                           title: 'Project ID',               fmt: { link: '/projects/' }  }
     project_ids:              { data: 'project_ids',                          title: 'Projects',                 fmt: { link: '/projects/' } }
     plate_id:                 { data: 'plate_id',                             title: 'Plate' }
     properly_mapped_reads:    { data: 'properly_mapped_reads',                title: '# properly mapped reads',  fmt: { type: 'int' },    visible: 'false'}
     reviewed:                 { data: 'reviewed',                             title: 'Review status' }
-    review_statuses:          { data: 'review_statuses',                      title: 'Review' }
+    review_statuses:          { data: 'aggregated.review_statuses',           title: 'Review' }
     run_id:                   { data: 'run_id',                               title: 'Run ID',                   fmt: { link: '/run/' } }
-    run_ids:                  { data: 'run_ids',                              title: 'Run ids',                  fmt: { link: '/run/' } }
+    run_ids:                  { data: 'aggregated.run_ids',                   title: 'Run ids',                  fmt: { link: '/run/' } }
     sample_id:                { data: 'sample_id',                            title: 'Sample ID',                fmt: { link: '/sample/' } }
-    sample_ids:               { data: 'sample_ids',                           title: 'Sample list',              fmt: { link: '/sample/' } }
+    sample_ids:               { data: 'aggregated.sample_ids',                title: 'Sample list',              fmt: { link: '/sample/' } }
     freemix:                  { data: 'sample_contamination.freemix',         title: 'Freemix',                  fmt: { type: 'float',  max: .03}  }
     species_found:            { data: 'species_contamination',                title: 'Species found',            fmt: { name: 'species_contamination' } }
     species:                  { data: 'species',                              title: 'Species',                                                        visible: 'false'}
     useable:                  { data: 'useable',                              title: 'Useable' }
-    useable_statuses:         { data: 'useable_statuses',                     title: 'Useable'}
+    useable_statuses:         { data: 'aggregated.useable_statuses',          title: 'Useable'}
     user_sample_id:           { data: 'User Sample Name',                     title: 'User sample ID' }
     2D_barcode:               { data: '2D Barcode',                           title: 'FluidX barcode',                                                 visible: 'false' }
-    yield_in_gb:              { data: 'yield_in_gb',                          title: 'Yield (Gb)',               fmt: { type: 'float',  min: 120 } }
-    yield_q30_in_gb:          { data: 'yield_q30_in_gb',                      title: 'Yield Q30(Gb)',            fmt: { type: 'float',  min: 95 } }
+    yield_in_gb:              { data: 'aggregated.yield_in_gb',               title: 'Yield (Gb)',               fmt: { type: 'float',  min: 120 } }
+    yield_q30_in_gb:          { data: 'aggregated.yield_q30_in_gb',           title: 'Yield Q30(Gb)',            fmt: { type: 'float',  min: 95 } }
     reseacher:                { data: 'researcher_name',                      title: 'Researcher',                                                     visible: 'false' }
     open_date:                { data: 'open_date',                            title: 'Open Since',               fmt: { type: 'date' } }
     finished_date:            { data: 'finished_date',                        title: 'Date finished',            fmt: { type: 'date' },                visible: 'false' }
@@ -104,9 +105,9 @@ column_def:
     expected_yield_q30:       { data: 'Yield for Quoted Coverage (Gb)',       title: 'Expected Yield Q30 (Gb)',  fmt: { type: 'float' },               visible: 'false' }
     tissue_type:              { data: 'Sample Type',                          title: 'Tissue type',                                                    visible: 'false'}
     tumor_sample:             { data: 'Is Tumor Sample',                      title: 'Is Tumor Sample',                                                visible: 'false'}
-    trim_r1:                  { data: 'trim_r1',                              title: 'Read 1 Max length',                                              visible: 'false'}
-    trim_r2:                  { data: 'trim_r2',                              title: 'Read 2 Max length',                                              visible: 'false'}
-    tiles_filtered:           { data: 'tiles_filtered',                       title: 'Tile removed',                                                   visible: 'false'}
+    trim_r1:                  { data: 'aggregated.trim_r1',                   title: 'Read 1 Max length',                                              visible: 'false'}
+    trim_r2:                  { data: 'aggregated.trim_r2',                   title: 'Read 2 Max length',                                              visible: 'false'}
+    tiles_filtered:           { data: 'aggregated.tiles_filtered',            title: 'Tile removed',                                                   visible: 'false'}
 
 # Datatables tables definition
 # the remaining top level entries each define a table with a list of column
@@ -125,7 +126,8 @@ runs:
     - clean_pc_q30
     - clean_yield_in_gb
     - clean_yield_q30_in_gb
-    - pc_adapter
+    - pc_adaptor
+    - pc_opt_duplicate_reads
     - proc_status
     - review_statuses
     - useable_statuses
@@ -190,10 +192,10 @@ demultiplexing:
     - project_id
     - sample_id
     - passing_filter_reads
-    - { column_def: 'yield_in_gb',  fmt: { type: 'float' }, visible: 'false' }
-    - { column_def: 'clean_yield_in_gb',  fmt: { type: 'float' }, visible: 'true' }
+    - { column_def: 'yield_in_gb', data: 'aggregated.yield_in_gb',  fmt: { type: 'float' }, visible: 'false' }
+    - { column_def: 'clean_yield_in_gb', data: 'aggregated.clean_yield_in_gb', fmt: { type: 'float' }, visible: 'true' }
     - { column_def: 'yield_q30_in_gb',  fmt: { type: 'float'}, visible: 'false' }
-    - { column_def: 'clean_yield_q30_in_gb',  fmt: { type: 'float' }, visible: 'true' }
+    - { column_def: 'clean_yield_q30_in_gb', fmt: { type: 'float' }, visible: 'true' }
     - pc_q30
     - pc_q30_r1
     - pc_q30_r2
@@ -201,7 +203,12 @@ demultiplexing:
     - clean_pc_q30_r1
     - clean_pc_q30_r2
     - lane_pc_optical_dups
-    - pc_adapter
+    - pc_adaptor
+    - pc_mapped_reads
+    - pc_duplicate_reads
+    - pc_opt_duplicate_reads
+    - mean_insert_size
+    - mean_coverage
     - reviewed
     - useable
 
@@ -209,7 +216,7 @@ demultiplexing:
 lane_aggregation:
     - lane_number
     - sample_ids
-    - passing_filter_reads
+    - { column_def: 'passing_filter_reads',  data: 'aggregated.passing_filter_reads' }
     - pc_pass_filter
     - { column_def: 'yield_in_gb',  fmt: { type: 'float',  min: 120 }, visible: 'false' }
     - { column_def: 'clean_yield_in_gb',  fmt: { type: 'float',  min: 120 }, visible: 'true' }
@@ -224,9 +231,10 @@ lane_aggregation:
     - clean_pc_q30
     - clean_pc_q30_r1
     - clean_pc_q30_r2
-    - lane_pc_optical_dups
-    - pc_adapter
-    - { column_def: 'cv',  visible: 'false' }
+    - { column_def: 'lane_pc_optical_dups',  data: 'aggregated.lane_pc_optical_dups' }
+    - pc_opt_duplicate_reads
+    - pc_adaptor
+    - cv
     - review_statuses
     - useable_statuses
 
@@ -245,7 +253,7 @@ samples:
     - library_type
     - species
     - { column_def: 'clean_yield_in_gb', title: 'Yield (Gb)' }
-    - { column_def: 'clean_yield_q30', title: 'Yield Q30 (Gb)' }
+    - { column_def: 'clean_yield_q30_in_gb', title: 'Yield Q30 (Gb)' }
     - expected_yield
     - expected_yield_q30
     - tissue_type
@@ -301,7 +309,7 @@ sample_run_elements:
     - clean_pc_q30_r2
     - clean_pc_q30
     - lane_pc_optical_dups
-    - pc_adapter
+    - pc_adaptor
     - reviewed
     - useable
 

--- a/etc/column_mappings.yaml
+++ b/etc/column_mappings.yaml
@@ -317,6 +317,11 @@ sample_run_elements:
     - clean_pc_q30
     - lane_pc_optical_dups
     - pc_adaptor
+    - pc_mapped_reads
+    - pc_duplicate_reads
+    - pc_opt_duplicate_reads
+    - mean_insert_size
+    - mean_coverage
     - reviewed
     - useable
 

--- a/etc/column_mappings.yaml
+++ b/etc/column_mappings.yaml
@@ -29,14 +29,14 @@ column_def:
     library_id:               { data: 'library_id',                           title: 'Library ID' }
     library_type:             { data: 'library_type',                         title: 'Library',                                                        visible: 'false' }
     genotype_match:           { data: 'aggregated.genotype_match',            title: 'Genotype'   }
-    mean_insert_size:         { data: 'mapping_metrics.mean_insert_size',     title: 'Avg Insert Size',           fmt: { type: 'float' }, visible: 'false' }
+    mean_insert_size:         { data: 'mapping_metrics.mean_insert_size',     title: 'Avg Insert Size',          fmt: { type: 'float' }, visible: 'false' }
     mapped_reads:             { data: 'mapped_reads',                         title: '# mapped reads',           fmt: { type: 'int' },    visible: 'false'  }
     matching_snps:            { data: 'genotype_validation.matching_snps',    title: 'Matching snps' ,                                                 visible: 'false'}
     median_coverage:          { data: 'median_coverage',                      title: 'Median coverage',          fmt: { type: 'float', min: {field: 'Coverage (X)', default: 30} } }
     mean_coverage:            { data: 'coverage.mean',                        title: 'Mean coverage',            fmt: { type: 'float', min: {field: 'Coverage (X)', default: 30} } }
-    coverage_5X:              { data: 'coverage',                             title: '% covered 5X',             fmt: { name: 'coverage_5X', type: 'percentage', min: 85 }, visible: 'false' }
-    coverage_15X:             { data: 'coverage',                             title: '% covered 15X',            fmt: { name: 'coverage_15X', type: 'percentage', min: 85 } }
-    evenness:                 { data: 'coverage.evenness',                    title: '% Evenness',               fmt: { type: 'ratio_percentage', min: .8 } }
+    coverage_5X:              { data: 'coverage',                             title: '% covered 5X',             fmt: { name: 'coverage_5X', type: 'percentage' }, visible: 'false' }
+    coverage_15X:             { data: 'coverage',                             title: '% covered 15X',            fmt: { name: 'coverage_15X', type: 'percentage' } }
+    evenness:                 { data: 'coverage.evenness',                    title: '% Evenness',               fmt: { type: 'ratio_percentage' } }
     mismatching_snps:         { data: 'genotype_validation.mismatching_snps', title: 'Mismatching snps' ,                                              visible: 'false'}
     nb_quoted_samples:        { data: 'nb_quoted_samples',                    title: 'Quoted Samples' ,          class_name: 'text-center sum' }
     nb_samples_delivered:     { data: 'aggregated.samples_delivered',         title: 'Samples Delivered',        fmt: {link_format_function: 'count_entities', link: '/sample/' }, class_name: 'text-center sum' }
@@ -62,9 +62,8 @@ column_def:
     gender_match:             { data: 'aggregated.gender_match',              title: 'Gender' }
     passing_filter_reads:     { data: 'passing_filter_reads',                 title: 'Passing-filter reads',     fmt: { type: 'int' } }
     pc_adaptor:               { data: 'aggregated.pc_adaptor',                title: '% Adapter',                fmt: { type: 'percentage', max: 5 } }
-    pc_callable:              { data: 'pc_callable',                          title: '% callable',               fmt: { type: 'percentage', min: 70 }, visible: 'false' }
     pc_duplicate_reads:       { data: 'aggregated.pc_duplicate_reads',        title: '% duplicate reads',        fmt: { type: 'percentage', max: 35 } }
-    pc_opt_duplicate_reads:   { data: 'aggregated.pc_opt_duplicate_reads',    title: '% opt duplicate reads',    fmt: { type: 'percentage', max: 20 } }
+    pc_opt_duplicate_reads:   { data: 'aggregated.pc_opt_duplicate_reads',    title: '% opt duplicate reads',    fmt: { type: 'percentage', max: 25 } }
     pc_mapped_reads:          { data: 'aggregated.pc_mapped_reads',           title: '% mapped reads',           fmt: { type: 'percentage', min: 90 } }
     pc_pass_filter:           { data: 'aggregated.pc_pass_filter',            title: '% Pass filter',            fmt: { type: 'percentage' } }
     pc_properly_mapped_reads: { data: 'aggregated.pc_properly_mapped_reads',  title: '% properly mapped reads',  fmt: { type: 'percentage' }, visible: 'false' }
@@ -259,8 +258,8 @@ samples:
     - current_lims_status
     - library_type
     - species
-    - { column_def: 'clean_yield_in_gb', title: 'Yield (Gb)' }
-    - { column_def: 'clean_yield_q30_in_gb', title: 'Yield Q30 (Gb)' }
+    - { column_def: 'clean_yield_in_gb', title: 'Yield (Gb)', fmt: { type: 'float', min: {field: 'Required Yield (Gb)', default: 120} } }
+    - { column_def: 'clean_yield_q30_in_gb', title: 'Yield Q30 (Gb)', fmt: { type: 'float', min: {field: 'Yield for Quoted Coverage (Gb)', default: 95} } }
     - expected_yield
     - expected_yield_q30
     - tissue_type
@@ -282,7 +281,6 @@ samples:
     - coverage_15X
     - evenness
     - species_found
-    - pc_callable
     - gender_match
     - called_gender
     - provided_gender

--- a/etc/column_mappings.yaml
+++ b/etc/column_mappings.yaml
@@ -100,6 +100,8 @@ column_def:
     cst_date:                 { data: 'cst_date',                             title: 'Date CST',                 fmt: { type: 'datetime' },            visible: 'false' }
     run_status:               { data: 'run_status',                           title: 'Lims status' }
     instrument_id:            { data: 'instrument_id',                        title: 'Instrument ID' }
+    nb_reads:                 { data: 'nb_reads',                             title: 'Nb Reads',                 fmt: { type: 'int' },                  visible: 'false' }
+    nb_cycles:                { data: 'nb_cycles',                            title: 'Nb Cycles',                fmt: { type: 'int' },                  visible: 'false' }
     current_lims_status:      { data: 'current_status',                       title: 'Lims Status' }
     expected_yield:           { data: 'Required Yield (Gb)',                  title: 'Expected Yield (Gb)',      fmt: { type: 'float' },               visible: 'false'  }
     expected_yield_q30:       { data: 'Yield for Quoted Coverage (Gb)',       title: 'Expected Yield Q30 (Gb)',  fmt: { type: 'float' },               visible: 'false' }
@@ -116,6 +118,8 @@ column_def:
 runs:
     - run_id
     - instrument_id
+    - nb_reads
+    - nb_cycles
     - run_status
     - cst_date
     - project_ids

--- a/etc/column_mappings.yaml
+++ b/etc/column_mappings.yaml
@@ -139,6 +139,7 @@ projects:
     - nb_samples
     - nb_samples_reviewed
     - nb_samples_delivered
+    - proc_status
     - _created
 
 

--- a/etc/column_mappings.yaml
+++ b/etc/column_mappings.yaml
@@ -108,6 +108,7 @@ column_def:
     trim_r1:                  { data: 'aggregated.trim_r1',                   title: 'Read 1 Max length',                                              visible: 'false'}
     trim_r2:                  { data: 'aggregated.trim_r2',                   title: 'Read 2 Max length',                                              visible: 'false'}
     tiles_filtered:           { data: 'aggregated.tiles_filtered',            title: 'Tile removed',                                                   visible: 'false'}
+    family_id:                { data: 'Family ID',                            title: 'Family ID (SGP)',                                                visible: 'false'}
 
 # Datatables tables definition
 # the remaining top level entries each define a table with a list of column
@@ -248,6 +249,7 @@ unexpected_barcodes:
 samples:
     - sample_id
     - user_sample_id
+    - family_id
     - 2D_barcode
     - current_lims_status
     - library_type

--- a/reporting_app/__init__.py
+++ b/reporting_app/__init__.py
@@ -234,7 +234,7 @@ def project_reports():
 @app.route('/samples/<view_type>')
 @flask_login.login_required
 def report_samples(view_type):
-    six_month_ago = datetime.datetime.now() - datetime.timedelta(days=183)
+    year_ago = datetime.datetime.now() - datetime.timedelta(days=365)
     if view_type == 'all':
         ajax_call = {
             'func_name': 'merge_multi_sources_keep_first',
@@ -254,8 +254,8 @@ def report_samples(view_type):
                 construct_url('samples', where={'aggregated.most_recent_proc.status': 'processing'},
                               max_results=10000),
                 construct_url('lims/status/sample_status',
-                              match={'createddate': six_month_ago.strftime(settings.DATE_FORMAT)}),
-                construct_url('lims/samples', match={'createddate': six_month_ago.strftime(settings.DATE_FORMAT)})
+                              match={'createddate': year_ago.strftime(settings.DATE_FORMAT)}),
+                construct_url('lims/samples', match={'createddate': year_ago.strftime(settings.DATE_FORMAT)})
             ],
             'merge_on': 'sample_id'
         }
@@ -265,8 +265,8 @@ def report_samples(view_type):
             'func_name': 'merge_multi_sources_keep_first',
             'api_urls': [
                 construct_url('samples', where={'useable': 'not%20marked', 'aggregated.most_recent_proc.status': 'finished'}, max_results=10000),
-                construct_url('lims/status/sample_status', match={'createddate': six_month_ago.strftime(settings.DATE_FORMAT)}),
-                construct_url('lims/samples', match={'createddate': six_month_ago.strftime(settings.DATE_FORMAT)})
+                construct_url('lims/status/sample_status', match={'createddate': year_ago.strftime(settings.DATE_FORMAT)}),
+                construct_url('lims/samples', match={'createddate': year_ago.strftime(settings.DATE_FORMAT)})
             ],
             'merge_on': 'sample_id'
         }

--- a/reporting_app/__init__.py
+++ b/reporting_app/__init__.py
@@ -384,7 +384,7 @@ def report_sample(sample_id):
 def plotting_report():
     return render_template(
         'charts.html',
-        api_url=construct_url('aggregate/run_elements', paginate=False),
+        api_url=construct_url('run_elements', max_results=1000000),
         ajax_token=get_token()
     )
 

--- a/reporting_app/__init__.py
+++ b/reporting_app/__init__.py
@@ -234,7 +234,7 @@ def project_reports():
 @app.route('/samples/<view_type>')
 @flask_login.login_required
 def report_samples(view_type):
-    year_ago = datetime.datetime.now() - datetime.timedelta(days=365)
+    year_ago = datetime.datetime.now() - datetime.timedelta(days=182)
     if view_type == 'all':
         ajax_call = {
             'func_name': 'merge_multi_sources_keep_first',

--- a/reporting_app/static/charts.js
+++ b/reporting_app/static/charts.js
@@ -161,6 +161,8 @@ function plotCharts(input_data) {
     });
     // Add filtered data
     input_data.map(function(element) {
+        element['yield_in_gb'] = element['aggregated']['yield_in_gb']
+        element['yield_q30_in_gb'] = element['aggregated']['yield_q30_in_gb']
         if (element['useable'] == 'yes'){
             element['useable_yield_in_gb'] = element['yield_in_gb'];
         }else{

--- a/reporting_app/templates/project_report.html
+++ b/reporting_app/templates/project_report.html
@@ -1,0 +1,12 @@
+{% extends 'untabbed_datatables.html' %}
+{% from 'proc_report.html' import proc_report, proc_header %}
+
+{% block head %}
+{{ proc_header() }}
+{{ super() }}
+{% endblock %}
+
+{% block content %}
+{{ super() }}
+{{ proc_report(procs) }}
+{% endblock %}

--- a/reporting_app/templates/reporting_base.html
+++ b/reporting_app/templates/reporting_base.html
@@ -30,6 +30,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Samples<b class="caret"></b></a>
                     <ul class="dropdown-menu">
                         <li><a href="/samples/all">All</a></li>
+                        <li><a href="/samples/processing">Processing</a></li>
                         <li><a href="/samples/toreview">To review</a></li>
                     </ul>
                 </li>

--- a/rest_api/aggregation/database_hooks.py
+++ b/rest_api/aggregation/database_hooks.py
@@ -134,7 +134,7 @@ class UniqDict(Calculation):
         else:
             elements = [e[self.key] for e in elements if e]
 
-        return list(set(elements))
+        return sorted(set(elements))
 
 
 class NbUniqueDicts(Calculation):  # TODO: Should replace server_side.NbUniqueElements
@@ -327,6 +327,19 @@ class Sample(DataRelation):
             'coverage_at_5X': Percentage('coverage.bases_at_coverage.bases_at_5X', 'coverage.genome_size'),
             'coverage_at_15X': Percentage('coverage.bases_at_coverage.bases_at_15X', 'coverage.genome_size'),
             'most_recent_proc': MostRecent('analysis_driver_procs')
+        },
+        {
+            'mean_coverage_from_re': Total('run_elements.coverage.mean'),
+            'bam_file_reads_from_re': Total('run_elements.coverage.bam_file_reads'),
+            'mapped_reads_from_re': Total('run_elements.coverage.mapped_reads'),
+            'duplicate_reads_from_re': Total('run_elements.coverage.duplicate_reads'),
+            'picard_dup_reads_from_re': Total('run_elements.coverage.picard_dup_reads'),
+            'picard_opt_dup_reads_from_re': Total('run_elements.coverage.picard_opt_dup_reads')
+        },
+        {
+            'pc_mapped_reads_from_re': Percentage('aggregated.mapped_reads_from_re', 'aggregated.bam_file_reads_from_re'),
+            'pc_duplicate_reads_from_re': Percentage('aggregated.duplicate_reads_from_re', 'aggregated.bam_file_reads_from_re'),
+            'pc_opt_duplicate_reads_from_re': Percentage('aggregated.picard_opt_dup_reads_from_re', 'aggregated.bam_file_reads_from_re'),
         }
     ]
 

--- a/rest_api/aggregation/database_hooks.py
+++ b/rest_api/aggregation/database_hooks.py
@@ -123,6 +123,20 @@ class MostRecent(Calculation):  # TODO: Should replace server_side.MostRecent
             return procs[-1]
 
 
+class UniqDict(Calculation):
+    def __init__(self, *args, filter_func=None, key=None):
+        super().__init__(*args, filter_func=filter_func)
+        self.key = key
+
+    def _expression(self, elements):
+        if self.filter_func:
+            elements = [e[self.key] for e in elements if self.filter_func(e)]
+        else:
+            elements = [e[self.key] for e in elements if e]
+
+        return list(set(elements))
+
+
 class NbUniqueDicts(Calculation):  # TODO: Should replace server_side.NbUniqueElements
     def __init__(self, *args, filter_func=None, key=None):
         super().__init__(*args, filter_func=filter_func)
@@ -280,9 +294,9 @@ class Project(DataRelation):
     id_field = 'project_id'
     aggregated_fields = [
         {
-            'nb_samples': NbUniqueDicts('samples', key='sample_id'),
-            'nb_samples_reviewed': NbUniqueDicts('samples', key='sample_id', filter_func=lambda s: s.get('reviewed') in ('pass', 'fail')),
-            'nb_samples_delivered': NbUniqueDicts('samples', key='sample_id', filter_func=lambda s: s.get('delivered') == 'yes'),
+            'samples': UniqDict('samples', key='sample_id'),
+            'samples_reviewed': UniqDict('samples', key='sample_id', filter_func=lambda s: s.get('reviewed') in ('pass', 'fail')),
+            'samples_delivered': UniqDict('samples', key='sample_id', filter_func=lambda s: s.get('delivered') == 'yes'),
             'most_recent_proc': MostRecent('analysis_driver_procs')
         }
     ]

--- a/rest_api/aggregation/database_hooks.py
+++ b/rest_api/aggregation/database_hooks.py
@@ -197,7 +197,11 @@ class RunElement(DataRelation):
             'pc_adaptor': Percentage(
                 Add('adaptor_bases_removed_r1', 'adaptor_bases_removed_r2'),
                 Add('bases_r1', 'bases_r2')
-            )
+            ),
+            'pc_mapped_reads': Percentage('mapping_metrics.mapped_reads', 'mapping_metrics.bam_file_reads'),
+            'pc_duplicate_reads': Percentage('mapping_metrics.duplicate_reads', 'mapping_metrics.bam_file_reads'),
+            'pc_opt_duplicate_reads': Percentage('mapping_metrics.picard_opt_dup_reads', 'mapping_metrics.bam_file_reads'),
+
         }
     ]
 
@@ -224,6 +228,10 @@ class Run(DataRelation):
             'pc_adaptor': Percentage(
                 Add(Total('run_elements.adaptor_bases_removed_r1'), Total('run_elements.adaptor_bases_removed_r2')),
                 Add('aggregated.bases_r1', 'aggregated.bases_r2')
+            ),
+            'pc_opt_duplicate_reads': Percentage(
+                Total('run_elements.mapping_metrics.picard_opt_dup_reads'),
+                Total('run_elements.mapping_metrics.bam_file_reads')
             ),
             'most_recent_proc': MostRecent('analysis_driver_procs')
         }
@@ -252,6 +260,11 @@ class Lane(DataRelation):
                 Add('aggregated.bases_r1', 'aggregated.bases_r2')
             ),
             'lane_pc_optical_dups': FirstElement('run_elements.lane_pc_optical_dups'),  # TODO: fix this in the schema
+            'pc_duplicate_reads': Percentage('mapping_metrics.duplicate_reads', 'mapping_metrics.bam_file_reads'),
+            'pc_opt_duplicate_reads': Percentage(
+                Total('run_elements.mapping_metrics.picard_opt_dup_reads'),
+                Total('run_elements.mapping_metrics.bam_file_reads')
+            ),
             'useable_statuses': ToSet('run_elements.useable', filter_func=not_unknown_barcode),
             'review_statuses': ToSet('run_elements.reviewed', filter_func=not_unknown_barcode),
         }

--- a/rest_api/aggregation/server_side/expressions.py
+++ b/rest_api/aggregation/server_side/expressions.py
@@ -77,7 +77,11 @@ class Accumulation(Calculation):
         resolved_subelements = []
         for s in subelements:
             for q in queries[1:]:
-                s = s.get(q)
+                if q in s:
+                    s = s.get(q)
+                else:
+                    s = None
+                    break
             resolved_subelements.append(s)
 
         return resolved_subelements

--- a/rest_api/aggregation/server_side/queries.py
+++ b/rest_api/aggregation/server_side/queries.py
@@ -5,7 +5,7 @@ aggregate_run_element = {
     'pc_q30_r1': Percentage('q30_bases_r1', 'bases_r1'),
     'pc_q30_r2': Percentage('q30_bases_r2', 'bases_r2'),
     'pc_q30': Percentage(Add('q30_bases_r1', 'q30_bases_r2'), Add('bases_r1', 'bases_r2')),
-    'yield_in_gb': Divide(Add('bases_r1', 'bases_r2'), Constant(1000000000))
+    'yield_in_gb': Divide(Add('bases_r1', 'bases_r2'), 1000000000)
 }
 
 aggregate_sample = {
@@ -16,8 +16,8 @@ aggregate_sample = {
         Add('clean_q30_bases_r1', 'clean_q30_bases_r2'),
         Add('clean_bases_r1', 'clean_bases_r2')
     ),
-    'clean_yield_in_gb': Divide(Add('clean_bases_r1', 'clean_bases_r2'), Constant(1000000000)),
-    'clean_yield_q30': Divide(Add('clean_q30_bases_r1', 'clean_q30_bases_r2'), Constant(1000000000)),
+    'clean_yield_in_gb': Divide(Add('clean_bases_r1', 'clean_bases_r2'), 1000000000),
+    'clean_yield_q30': Divide(Add('clean_q30_bases_r1', 'clean_q30_bases_r2'), 1000000000),
     'pc_mapped_reads': Percentage('mapped_reads', 'bam_file_reads'),
     'pc_properly_mapped_reads': Percentage('properly_mapped_reads', 'bam_file_reads'),
     'pc_duplicate_reads': Percentage('duplicate_reads', 'bam_file_reads')
@@ -28,7 +28,7 @@ aggregate_lane = {
     'pc_q30_r2': Percentage('q30_bases_r2', 'bases_r2'),
     'pc_q30': Percentage(Add('q30_bases_r1', 'q30_bases_r2'), Add('bases_r1', 'bases_r2')),
     'pc_pass_filter': Percentage('passing_filter_reads', 'total_reads'),
-    'yield_in_gb': Divide(Add('bases_r1', 'bases_r2'), Constant(1000000000)),
+    'yield_in_gb': Divide(Add('bases_r1', 'bases_r2'), 1000000000),
     'cv': CoefficientOfVariation(
         'run_elements.passing_filter_reads',
         filter_func=lambda x: x.get('barcode') != 'unknown'
@@ -41,10 +41,10 @@ aggregate_run = {
     'pc_q30': Percentage(Add('q30_bases_r1', 'q30_bases_r2'), Add('bases_r1', 'bases_r2')),
     # 'pc_pass_filter': Percentage('passing_filter_reads', 'total_reads'),
     'project_ids': ToSet('run_elements.project_id'),
-    'yield_in_gb': Divide(Add('bases_r1', 'bases_r2'), Constant(1000000000)),
-    'yield_q30_in_gb': Divide(Add('q30_bases_r1', 'q30_bases_r2'), Constant(1000000000)),
-    'clean_yield_in_gb': Divide(Add('clean_bases_r1', 'clean_bases_r2'), Constant(1000000000)),
-    'clean_yield_q30_in_gb': Divide(Add('clean_q30_bases_r1', 'clean_q30_bases_r2'), Constant(1000000000)),
+    'yield_in_gb': Divide(Add('bases_r1', 'bases_r2'), 1000000000),
+    'yield_q30_in_gb': Divide(Add('q30_bases_r1', 'q30_bases_r2'), 1000000000),
+    'clean_yield_in_gb': Divide(Add('clean_bases_r1', 'clean_bases_r2'), 1000000000),
+    'clean_yield_q30_in_gb': Divide(Add('clean_q30_bases_r1', 'clean_q30_bases_r2'), 1000000000),
     'review_statuses': ToSet('run_elements.reviewed'),
     'useable_statuses': ToSet('run_elements.useable')
 }

--- a/rest_api/limsdb/queries/__init__.py
+++ b/rest_api/limsdb/queries/__init__.py
@@ -140,7 +140,7 @@ def runs_info(session, time_since=None, run_ids=None, run_status=None):
         .join(t.ContainerPlacement.container) \
         .join(t.Artifact.samples) \
         .join(t.Sample.project) \
-        .filter(t.ProcessUdfView.udfname.in_(('Run Status', 'RunID', 'InstrumentID'))) \
+        .filter(t.ProcessUdfView.udfname.in_(('Run Status', 'RunID', 'InstrumentID', 'Cycle', 'Read'))) \
         .filter(t.ProcessType.displayname == 'AUTOMATED - Sequence')
 
     if time_since:

--- a/rest_api/limsdb/queries/run_status.py
+++ b/rest_api/limsdb/queries/run_status.py
@@ -21,7 +21,9 @@ class Run:
             'run_status': self.udfs['Run Status'],
             'sample_ids': sorted(list(self.samples)),
             'project_ids': sorted(list(self.projects)),
-            'instrument_id': self.udfs['InstrumentID']
+            'instrument_id': self.udfs['InstrumentID'],
+            'nb_reads': self.udfs['Read'],
+            'nb_cycles': self.udfs['Cycle']
         }
 
 

--- a/tests/test_rest_api/test_aggregation/test_database_hooks.py
+++ b/tests/test_rest_api/test_aggregation/test_database_hooks.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import json
 from unittest import TestCase
@@ -9,6 +10,37 @@ from math import sqrt
 from datetime import datetime
 from rest_api.aggregation import database_hooks
 from unittest.mock import patch
+
+
+run_element1 = {
+    'run_element_id': '150724_test_1_ATGC', 'run_id': '150724_test', 'project_id': 'a_project',
+    'sample_id': 'a_sample', 'lane': 1, 'barcode': 'ATGC', 'library_id': 'a_library',
+    'bases_r1': 1500000000, 'bases_r2': 1400000000, 'q30_bases_r1': 1400000000, 'q30_bases_r2': 1300000000,
+    'clean_bases_r1': 1300000000, 'clean_bases_r2': 1200000000, 'clean_q30_bases_r1': 1200000000,
+    'clean_q30_bases_r2': 1100000000, 'total_reads': 9190, 'passing_filter_reads': 8451,
+    'pc_reads_in_lane': 54.0, 'reviewed': 'not reviewed', 'useable': 'yes', 'clean_reads': 1337,
+    'lane_pc_optical_dups': 0.1, 'adaptor_bases_removed_r1': 1337, 'adaptor_bases_removed_r2': 1338,
+    'mapping_metrics':{
+        'bam_file_reads': 8420, 'mapped_reads': 8200, 'duplicate_reads': 1000, 'properly_mapped_reads': 8100,
+        'picard_dup_reads': 1010, 'picard_opt_dup_reads': 500, 'picard_est_lib_size': 10000, 'mean_insert_size': 450.2,
+        'std_dev_insert_size': 68.4, 'median_insert_size': 432.5, 'median_abs_dev_insert_size': 58.5
+    }
+}
+
+run_element2 = {
+    'run_element_id': '150724_test_1_ATGA', 'run_id': '150724_test', 'project_id': 'a_project',
+    'sample_id': 'a_sample', 'lane': 1, 'barcode': 'ATGC', 'library_id': 'a_library',
+    'bases_r1': 1500000001, 'bases_r2': 1400000001, 'q30_bases_r1': 1400000001, 'q30_bases_r2': 1300000001,
+    'clean_bases_r1': 1300000001, 'clean_bases_r2': 1200000001, 'clean_q30_bases_r1': 1200000001,
+    'clean_q30_bases_r2': 1100000001, 'total_reads': 9180, 'passing_filter_reads': 8461,
+    'pc_reads_in_lane': 54.1, 'reviewed': 'pass', 'useable': 'yes', 'clean_reads': 1338,
+    'lane_pc_optical_dups': 0.1, 'adaptor_bases_removed_r1': 1339, 'adaptor_bases_removed_r2': 1340,
+    'mapping_metrics': {
+        'bam_file_reads': 8620, 'mapped_reads': 8300, 'duplicate_reads': 1100, 'properly_mapped_reads': 8200,
+        'picard_dup_reads': 1110, 'picard_opt_dup_reads': 600, 'picard_est_lib_size': 10000, 'mean_insert_size': 450.2,
+        'std_dev_insert_size': 68.4, 'median_insert_size': 432.5, 'median_abs_dev_insert_size': 58.5
+    }
+}
 
 
 class TestDatabaseHooks(TestCase):
@@ -26,26 +58,7 @@ class TestDatabaseHooks(TestCase):
         cls.patched_auth.start()
 
     def setUp(self):
-        self.run_elements = [
-            {
-                'run_element_id': '150724_test_1_ATGC', 'run_id': '150724_test', 'project_id': 'a_project',
-                'sample_id': 'a_sample', 'lane': 1, 'barcode': 'ATGC', 'library_id': 'a_library',
-                'bases_r1': 1500000000, 'bases_r2': 1400000000, 'q30_bases_r1': 1400000000, 'q30_bases_r2': 1300000000,
-                'clean_bases_r1': 1300000000, 'clean_bases_r2': 1200000000, 'clean_q30_bases_r1': 1200000000,
-                'clean_q30_bases_r2': 1100000000, 'total_reads': 9190, 'passing_filter_reads': 8451,
-                'pc_reads_in_lane': 54.0, 'reviewed': 'not reviewed', 'useable': 'yes', 'clean_reads': 1337,
-                'lane_pc_optical_dups': 0.1, 'adaptor_bases_removed_r1': 1337, 'adaptor_bases_removed_r2': 1338
-            },
-            {
-                'run_element_id': '150724_test_1_ATGA', 'run_id': '150724_test', 'project_id': 'a_project',
-                'sample_id': 'a_sample', 'lane': 1, 'barcode': 'ATGC', 'library_id': 'a_library',
-                'bases_r1': 1500000001, 'bases_r2': 1400000001, 'q30_bases_r1': 1400000001, 'q30_bases_r2': 1300000001,
-                'clean_bases_r1': 1300000001, 'clean_bases_r2': 1200000001, 'clean_q30_bases_r1': 1200000001,
-                'clean_q30_bases_r2': 1100000001, 'total_reads': 9180, 'passing_filter_reads': 8461,
-                'pc_reads_in_lane': 54.1, 'reviewed': 'pass', 'useable': 'yes', 'clean_reads': 1338,
-                'lane_pc_optical_dups': 0.1, 'adaptor_bases_removed_r1': 1339, 'adaptor_bases_removed_r2': 1340
-            }
-        ]
+        self.run_elements = [copy.deepcopy(run_element1), copy.deepcopy(run_element2)]
 
     def tearDown(self):
         for c in schema.content:
@@ -110,7 +123,8 @@ class TestDatabaseHooks(TestCase):
             'pc_pass_filter': 92.06314643440392, 'pc_q30_r1': 93.33333333555555, 'pc_q30_r2': 92.85714285969388,
             'pc_q30': 93.10344827824018, 'yield_in_gb': 5.800000002, 'yield_q30_in_gb': 5.400000002,
             'clean_yield_in_gb': 5.000000002, 'clean_yield_q30_in_gb': 4.600000002, 'clean_pc_q30': 92.0000000032,
-            'clean_pc_q30_r1': 92.30769231065089, 'clean_pc_q30_r2': 91.66666667013888
+            'clean_pc_q30_r1': 92.30769231065089, 'clean_pc_q30_r2': 91.66666667013888,
+            'pc_opt_duplicate_reads': 6.455399061032864,
         }
         obs = self.get('runs')[0]
         self.assert_dict_subsets(exp, obs['aggregated'])
@@ -233,28 +247,21 @@ class TestDatabaseHooks(TestCase):
         self.assert_dict_subsets(exp, self.get('lanes')[0]['aggregated'])
 
     def test_run_element_aggregation(self):
-        run_element = {
-            'run_element_id': '150724_test_1_ATGC', 'run_id': '150724_test', 'project_id': 'a_project',
-            'sample_id': 'a_sample', 'lane': 1, 'barcode': 'ATGC', 'library_id': 'a_library', 'bases_r1': 1500000000,
-            'bases_r2': 1400000000, 'q30_bases_r1': 1400000000, 'q30_bases_r2': 1300000000,
-            'clean_bases_r1': 1300000000, 'clean_bases_r2': 1200000000, 'clean_q30_bases_r1': 1200000000,
-            'clean_q30_bases_r2': 1100000000, 'adaptor_bases_removed_r1': 1337, 'adaptor_bases_removed_r2': 1338,
-            'total_reads': 9190, 'passing_filter_reads': 8451, 'pc_reads_in_lane': 54.0, 'reviewed': 'not reviewed',
-            'clean_reads': 1337
-        }
-
-        self.post('run_elements', run_element)
+        self.post('run_elements', self.run_elements[0])
         exp = {
             'pc_pass_filter': 91.95865070729053, 'pc_q30_r1': 93.33333333333333, 'pc_q30_r2': 92.85714285714286,
             'pc_q30': 93.10344827586206, 'yield_in_gb': 2.9, 'clean_yield_in_gb': 2.5, 'yield_q30_in_gb': 2.7,
             'clean_yield_q30_in_gb': 2.3, 'clean_pc_q30_r1': 92.3076923076923, 'clean_pc_q30_r2': 91.66666666666666,
-            'clean_pc_q30': 92.0
+            'clean_pc_q30': 92.0, 'pc_duplicate_reads': 11.87648456057007, 'pc_opt_duplicate_reads': 5.938242280285035,
+            'pc_mapped_reads': 97.38717339667458,
         }
         self.assert_dict_subsets(exp, self.get('run_elements')[0]['aggregated'])
 
         self.patch('run_elements', {'run_element_id': '150724_test_1_ATGC'}, {'clean_q30_bases_r1': 1201000000})
         exp.update({'clean_yield_q30_in_gb': 2.301, 'clean_pc_q30_r1': 92.38461538461539, 'clean_pc_q30': 92.04})
-        self.assert_dict_subsets(exp, self.get('run_elements')[0]['aggregated'])
+        obs = self.get('run_elements')[0]['aggregated']
+
+        self.assert_dict_subsets(exp, obs)
 
     def test_project_aggregation(self):
         samples = [
@@ -262,10 +269,10 @@ class TestDatabaseHooks(TestCase):
             {'sample_id': 'sample_3', 'project_id': 'test', 'delivered': 'yes'},
             {'sample_id': 'sample_4', 'project_id': 'test', 'reviewed': 'fail', 'delivered': 'yes'},
         ]
-
+        proc = {'proc_id': 'project_test_now', 'dataset_type': 'project', 'dataset_name': 'test'}
         self.post(
             'analysis_driver_procs',
-            {'proc_id': 'project_test_now', 'dataset_type': 'project', 'dataset_name': 'test'}
+            proc
         )
         self.post('samples', {'sample_id': 'sample_1', 'project_id': 'test'})
         self.post(
@@ -274,13 +281,16 @@ class TestDatabaseHooks(TestCase):
         )
 
         self.assert_dict_subsets(
-            {'nb_samples': 1, 'nb_samples_reviewed': 0, 'nb_samples_delivered': 0},
+            {'samples': ['sample_1'], 'samples_delivered': [], 'samples_reviewed': []},
             self.get('projects')[0]['aggregated']
         )
 
         self.post('samples', samples)
-        self.assert_dict_subsets(
-            {'nb_samples': 4, 'nb_samples_reviewed': 2, 'nb_samples_delivered': 2},
+        self.assert_dict_subsets({
+                'samples': ['sample_1', 'sample_2', 'sample_3', 'sample_4'],
+                'samples_reviewed': ['sample_2', 'sample_4'],
+                'samples_delivered': ['sample_3', 'sample_4']
+            },
             self.get('projects')[0]['aggregated']
         )
 


### PR DESCRIPTION
This PR make use of the aggregated data in the Reporting app web pages
It also adds new aggregated field for the mapping stats in the run elements and in samples

Also change the aggregated field in project to have the samples reviewed and or processed
It will require a retrigger of the aggregation for all run elements containing mapping information (less that two month old) and all projects
closes #144 
