### PR TITLE
Automatic run review update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
 install:
   - "pip install -r requirements.txt"
   - "pip install python-coveralls pytest-cov"
+  - "pip install coverage --upgrade"
 script:
   - py.test tests/ -v --cov reporting_app --cov rest_api --cov-report term-missing
   - node-qunit-phantomjs tests/js/run_tests.html

--- a/etc/review_thresholds.yaml
+++ b/etc/review_thresholds.yaml
@@ -4,7 +4,7 @@
 #  * value -- use to provide the threshold
 #  * comparison -- the comparator used
 #  * [optional] a formula that replace the metric key as the source of the data.
-#    formula can have nuerics or existing metric name
+#    formula can have numeric or existing metric name
 
 run:
     aggregated.yield_in_gb:

--- a/etc/review_thresholds.yaml
+++ b/etc/review_thresholds.yaml
@@ -1,26 +1,39 @@
 
 run:
-    yield_in_gb:
+    aggregated.yield_in_gb:
+        name: Run Yield
+        value: 960
+        comparison: '>'
+    aggregated.pc_q30:
+        name: Run PC Q30
+        value: 75
+        comparison: '>'
+
+lane:
+    aggregated.yield_in_gb:
         name: Yield
         value: 120
         comparison: '>'
-    pc_q30:
+    aggregated.pc_q30:
         name: PC Q30
         value: 75
         comparison: '>'
-    lane_pc_optical_dups:
-        name: Est. Dup. rate
-        value: 20
+    aggregated.pc_adaptor:
+        name: PC Adapter
+        value: 10
         comparison: '<'
-
+    aggregated.pc_opt_duplicate_reads:
+        name: Optical duplicate rate
+        value: 30
+        comparison: '<'
 
 sample:
     default:
-        clean_yield_in_gb:
+        aggregated.clean_yield_in_gb:
             name: Yield
             # value: populated in automatic_review.sample_config
             comparison: '>'
-        clean_yield_q30:
+        aggregated.clean_yield_q30:
             name: Yield Q30
             # value: populated in automatic_review.sample_config
             comparison: '>'
@@ -28,7 +41,7 @@ sample:
             name: Mean coverage
             # value: populated in automatic_review.sample_config
             comparison: '>'
-        pc_duplicate_reads:
+        aggregated.pc_duplicate_reads:
             name: Dup. rate
             value: 35
             comparison: '<'

--- a/etc/review_thresholds.yaml
+++ b/etc/review_thresholds.yaml
@@ -1,3 +1,10 @@
+# This file specify the thresholds used in the Automatic review process for runs lanes and samples
+# Each entry is a metric and needs a
+#  * name -- text use to describe the metric
+#  * value -- use to provide the threshold
+#  * comparison -- the comparator used
+#  * [optional] a formula that replace the metric key as the source of the data.
+#    formula can have nuerics or existing metric name
 
 run:
     aggregated.yield_in_gb:
@@ -7,6 +14,14 @@ run:
     aggregated.pc_q30:
         name: Run PC Q30
         value: 75
+        comparison: '>'
+    aggregated.pc_q30_r1:
+        name: Run PC Q30 R1
+        value: 70
+        comparison: '>'
+    aggregated.pc_q30_r2:
+        name: Run PC Q30 R2
+        value: 70
         comparison: '>'
 
 lane:
@@ -18,6 +33,14 @@ lane:
         name: PC Q30
         value: 75
         comparison: '>'
+    aggregated.pc_q30_r1:
+        name: PC Q30 R1
+        value: 70
+        comparison: '>'
+    aggregated.pc_q30_r2:
+        name: PC Q30 R2
+        value: 70
+        comparison: '>'
     aggregated.pc_adaptor:
         name: PC Adapter
         value: 10
@@ -26,6 +49,12 @@ lane:
         name: Optical duplicate rate
         value: 30
         comparison: '<'
+    compound_yield_adapter_duplicates:
+        formula: 'aggregated.yield_in_gb * (100 - aggregated.pc_adaptor)/100 * (100 - aggregated.pc_opt_duplicate_reads)/100'
+        name: Yield with no adapters and no duplicates
+        value: 95
+        comparison: '>'
+
 
 sample:
     default:

--- a/rest_api/actions/automatic_review.py
+++ b/rest_api/actions/automatic_review.py
@@ -1,4 +1,6 @@
 import os
+import re
+
 import yaml
 import datetime
 from cached_property import cached_property
@@ -18,6 +20,7 @@ review_thresholds = yaml.safe_load(open(cfg_path, 'r'))
 
 class AutomaticReviewer:
     reviewable_data = None
+    opposite = {'>': '<', '<': '>'}
 
     @staticmethod
     def eve_get(*args, **kwargs):
@@ -32,12 +35,28 @@ class AutomaticReviewer:
     def cfg(self):
         raise NotImplementedError
 
+    @staticmethod
+    def resolve_formula(data, formula):
+        modif_formula = formula
+        for word in re.findall('[\w.]+', formula):
+            value = query_dict(data, word)
+            if value:
+                modif_formula = modif_formula.replace(word, str(value))
+        try:
+            return eval(modif_formula)
+        except NameError:
+            return None
+
     @cached_property
     def failing_metrics(self):
         passfails = {}
 
         for metric in self.cfg:
-            metric_value = query_dict(self.reviewable_data, metric)
+            # resolve the formula if it exist otherwise resolve from the name of the metric
+            if 'formula' in self.cfg[metric]:
+                metric_value = self.resolve_formula(self.reviewable_data, self.cfg[metric]['formula'])
+            else:
+                metric_value = query_dict(self.reviewable_data, metric)
             comparison = self.cfg[metric]['comparison']
             compare_value = self.cfg[metric]['value']
 
@@ -51,20 +70,24 @@ class AutomaticReviewer:
             elif comparison == '<':
                 check = metric_value <= compare_value
 
-            elif comparison == 'agreeswith':
-                check = metric_value in (self.reviewable_data[compare_value['key']], compare_value['fallback'])
-
             passfails[metric] = 'pass' if check else 'fail'
 
-        return sorted(k for k, v in passfails.items() if v == 'fail')
+        return sorted(k for k, v in passfails.items() if v != 'pass')
+
+    @property
+    def failure_comment(self):
+        return 'Failed due to ' + ', '.join(['%s %s %s' % (
+            self.cfg.get(f, {}).get('name', f),
+            self.opposite.get((self.cfg.get(f, {}).get('comparison'))),
+            self.cfg.get(f, {}).get('value')
+        ) for f in self.failing_metrics ])
 
     @cached_property
     def _summary(self):
         if self.failing_metrics:
             return {
                 ELEMENT_REVIEWED: 'fail',
-                ELEMENT_REVIEW_COMMENTS: 'failed due to ' + ', '.join(
-                    [self.cfg.get(f, {}).get('name', f) for f in self.failing_metrics]),
+                ELEMENT_REVIEW_COMMENTS: self.failure_comment,
                 ELEMENT_REVIEW_DATE: self.current_time,
             }
         else:
@@ -212,12 +235,13 @@ class AutomaticSampleReviewer(Action, AutomaticReviewer):
         cfg['coverage.mean']['value'] = coverage
         return cfg
 
+
     @cached_property
     def _summary(self):
         summary = super()._summary
         if self.species == 'Homo sapiens' and self.sample_genotype is None:
             summary[ELEMENT_REVIEWED] = 'genotype missing'
-            summary[ELEMENT_REVIEW_COMMENTS] = 'failed due to missing genotype'
+            summary[ELEMENT_REVIEW_COMMENTS] = 'Failed due to missing genotype'
         return summary
 
     def push_review(self):

--- a/rest_api/actions/automatic_review.py
+++ b/rest_api/actions/automatic_review.py
@@ -72,7 +72,7 @@ class AutomaticReviewer:
 
             passfails[metric] = 'pass' if check else 'fail'
 
-        return sorted(k for k, v in passfails.items() if v != 'pass')
+        return sorted(k for k, v in passfails.items() if v == 'fail')
 
     @property
     def failure_comment(self):

--- a/rest_api/actions/automatic_review.py
+++ b/rest_api/actions/automatic_review.py
@@ -4,13 +4,13 @@ import datetime
 from cached_property import cached_property
 from egcg_core.clarity import connection, get_sample
 from egcg_core.constants import ELEMENT_REVIEW_COMMENTS, ELEMENT_REVIEW_DATE, ELEMENT_REVIEWED
+from egcg_core.util import query_dict
 from eve.methods.patch import patch_internal
 from eve.methods.get import get
 from werkzeug.exceptions import abort
 from config import rest_config
 from rest_api import settings
 from rest_api.actions.reviews import Action
-from rest_api.aggregation.database_side import _aggregate, queries
 
 cfg_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'etc', 'review_thresholds.yaml')
 review_thresholds = yaml.safe_load(open(cfg_path, 'r'))
@@ -18,6 +18,11 @@ review_thresholds = yaml.safe_load(open(cfg_path, 'r'))
 
 class AutomaticReviewer:
     reviewable_data = None
+
+    @staticmethod
+    def eve_get(*args, **kwargs):
+        res = get(*args, **kwargs)
+        return res[0].get('data')
 
     @cached_property
     def current_time(self):
@@ -27,22 +32,12 @@ class AutomaticReviewer:
     def cfg(self):
         raise NotImplementedError
 
-    @staticmethod
-    def _query(content, parts, ret_default=None):
-        top_level = content.copy()
-        item = None
-        for p in parts:
-            item = top_level.get(p)
-            if item is None:
-                return ret_default
-            top_level = item
-        return item
-
-    def get_failing_metrics(self):
+    @cached_property
+    def failing_metrics(self):
         passfails = {}
 
         for metric in self.cfg:
-            metric_value = self._query(self.reviewable_data, metric.split('.'))
+            metric_value = query_dict(self.reviewable_data, metric)
             comparison = self.cfg[metric]['comparison']
             compare_value = self.cfg[metric]['value']
 
@@ -63,14 +58,13 @@ class AutomaticReviewer:
 
         return sorted(k for k, v in passfails.items() if v == 'fail')
 
-    @property
+    @cached_property
     def _summary(self):
-        failing_metrics = self.get_failing_metrics()
-        if failing_metrics:
+        if self.failing_metrics:
             return {
                 ELEMENT_REVIEWED: 'fail',
                 ELEMENT_REVIEW_COMMENTS: 'failed due to ' + ', '.join(
-                    [self.cfg.get(f, {}).get('name', f) for f in failing_metrics]),
+                    [self.cfg.get(f, {}).get('name', f) for f in self.failing_metrics]),
                 ELEMENT_REVIEW_DATE: self.current_time,
             }
         else:
@@ -82,52 +76,71 @@ class AutomaticReviewer:
 
 
 class AutomaticLaneReviewer(AutomaticReviewer):
-    def __init__(self, aggregated_lane):
-        self.reviewable_data = aggregated_lane
-        self.run_id = aggregated_lane['run_id']
-        self.lane_number = aggregated_lane['lane_number']
+    def __init__(self, lane_metrics):
+        self.reviewable_data = lane_metrics
+        self.run_id = lane_metrics['run_id']
+        self.lane_number = lane_metrics['lane_number']
+
+    @property
+    def cfg(self):
+        return review_thresholds['lane']
+
+    @property
+    def run_elements(self):
+        return self.eve_get('run_elements', run_id=self.run_id, lane=self.lane_number)
+
+    def push_review(self):
+        for re in self.run_elements:
+            if re.get('barcode'):
+                patch_internal(
+                    'run_elements',
+                    payload=self._summary,
+                    run_id=self.run_id,
+                    lane=re.get('lane'),
+                    barcode=re.get('barcode')
+                )
+            else:
+                patch_internal(
+                    'run_elements',
+                    payload=self._summary,
+                    run_id=self.run_id,
+                    lane=re.get('lane')
+                )
+
+
+class AutomaticRunReviewer(Action, AutomaticLaneReviewer):
+    def __init__(self, request):
+        super().__init__(request)
+        self.run_id = self.request.form.get('run_id')
+
+        lanes = self.eve_get('lanes', run_id=self.run_id)
+        if not lanes:
+            abort(404, 'No data found for run id %s.' % self.run_id)
+        self.lane_reviewers = [AutomaticLaneReviewer(lane) for lane in lanes]
+
+    @property
+    def run_elements(self):
+        return self.eve_get('run_elements', run_id=self.run_id)
 
     @property
     def cfg(self):
         return review_thresholds['run']
 
-    def push_review(self):
-        docs = get('run_elements', run_id=self.run_id, lane=self.lane_number)
-        if len(docs[0].get('data')) == 1:
-            patch_internal(
-                'run_elements',
-                payload=self._summary,
-                run_id=self.run_id,
-                lane=self.lane_number
-            )
+    @cached_property
+    def reviewable_data(self):
+        data = self.eve_get('runs', run_id=self.run_id)
+        if data:
+            return data[0]
         else:
-            for re in docs[0].get('data'):
-                patch_internal(
-                    'run_elements',
-                    payload=self._summary,
-                    run_id=self.run_id,
-                    lane=self.lane_number,
-                    barcode=re.get('barcode')
-                )
-
-
-class AutomaticRunReviewer(Action):
-    def __init__(self, request):
-        super().__init__(request)
-        self.run_id = self.request.form.get('run_id')
-
-        lanes = _aggregate(
-            'run_elements',
-            queries.run_elements_group_by_lane,
-            request_args={'match': '{"run_id": "%s"}' % self.run_id}
-        )
-        if not lanes:
             abort(404, 'No data found for run id %s.' % self.run_id)
-        self.lane_reviewers = [AutomaticLaneReviewer(lane) for lane in lanes]
 
     def _perform_action(self):
-        for reviewer in self.lane_reviewers:
-            reviewer.push_review()
+        # Test the run first and only test the lanes if the run pass
+        if self.failing_metrics:
+            self.push_review()
+        else:
+            for reviewer in self.lane_reviewers:
+                reviewer.push_review()
         return {
             'action_id': self.run_id + self.date_started,
             'date_finished': self.now(),
@@ -152,15 +165,11 @@ class AutomaticSampleReviewer(Action, AutomaticReviewer):
 
     @cached_property
     def reviewable_data(self):
-        data = _aggregate(
-            'samples',
-            queries.sample,
-            request_args={'match': '{"sample_id": "%s"}' % self.sample_id}
-        )
+        data = self.eve_get('samples', sample_id=self.sample_id)
         if data:
             return data[0]
         else:
-            abort(404, 'No data found for run id %s.' % self.sample_id)
+            abort(404, 'No data found for sample id %s.' % self.sample_id)
 
     @property
     def sample_genotype(self):
@@ -198,12 +207,12 @@ class AutomaticSampleReviewer(Action, AutomaticReviewer):
         if not coverage:
             abort(404, 'Sample %s does not have a target coverage' % self.sample_id)
 
-        cfg['clean_yield_q30']['value'] = required_yield_q30
-        cfg['clean_yield_in_gb']['value'] = required_yield
+        cfg['aggregated.clean_yield_q30']['value'] = required_yield_q30
+        cfg['aggregated.clean_yield_in_gb']['value'] = required_yield
         cfg['coverage.mean']['value'] = coverage
         return cfg
 
-    @property
+    @cached_property
     def _summary(self):
         summary = super()._summary
         if self.species == 'Homo sapiens' and self.sample_genotype is None:

--- a/tests/test_rest_api/test_action/test_automatic_review.py
+++ b/tests/test_rest_api/test_action/test_automatic_review.py
@@ -1,18 +1,66 @@
 from unittest.mock import patch, Mock, PropertyMock
-from rest_api.actions import automatic_review as ar
+from rest_api.actions import automatic_review as ar, AutomaticRunReviewer
 from rest_api.actions.automatic_review import AutomaticSampleReviewer
-from rest_api.aggregation.database_side import queries
 from tests.test_rest_api import TestBase
 
 ppath = 'rest_api.actions.automatic_review.'
 
 passing_lane = {
-    'run_id': 'a_run', 'pc_q30': 83.01, 'lane_number': 1, 'pc_pass_filter': 75.27, 'yield_in_gb': 140.29, 'lane_pc_optical_dups': 9
+    'run_id': 'a_run',
+    'lane_number': 1,
+    'aggregated': {
+        'pc_pass_filter': 75.27,
+        'yield_in_gb': 140.29,
+        'pc_q30': 83.01,
+        'pc_opt_duplicate_reads': 21.1,
+        'pc_adaptor': 0.5
+    }
 }
 
 failing_lanes = [
-    {'run_id': 'a_run', 'pc_q30': 77.14, 'pc_pass_filter': 39.87, 'yield_in_gb': 74.30, 'lane_number': 2, 'lane_pc_optical_dups': 26},
-    {'run_id': 'a_run', 'pc_q30': 74.97, 'pc_pass_filter': 40.17, 'yield_in_gb': 74.86, 'lane_number': 3, 'lane_pc_optical_dups': 10}
+    {
+        'run_id': 'a_run',
+        'lane_number': 2,
+        'aggregated': {
+            'pc_q30': 77.14,
+            'pc_pass_filter': 39.87,
+            'yield_in_gb': 74.30,
+            'pc_opt_duplicate_reads': 30.1,
+            'pc_adaptor': 2.3
+        }
+    },
+    {
+        'run_id': 'a_run',
+        'lane_number': 3,
+        'aggregated': {
+            'pc_q30': 74.97,
+            'pc_pass_filter': 40.17,
+            'yield_in_gb': 74.86,
+            'pc_opt_duplicate_reads': 21.1,
+            'pc_adaptor': 0.3
+        }
+    }
+]
+
+failing_runs = [
+    {
+        'run_id': 'run1',
+        'aggregated': {
+            'pc_q30': 73.4,
+            "yield_in_gb": 1096.2,
+            "pc_opt_duplicate_reads": 22.59,
+            'pc_adaptor': 1.3
+        }
+    },
+    {
+        'run_id': 'run2',
+        'aggregated': {
+            'pc_q30': 81.5,
+            "yield_in_gb": 920.12,
+            "pc_opt_duplicate_reads": 30.59,
+            'pc_adaptor': 0.8
+        }
+    }
 ]
 
 run_elements = [{'barcode': 'b1'}, {'barcode': 'b2'}]
@@ -20,14 +68,16 @@ run_elements = [{'barcode': 'b1'}, {'barcode': 'b2'}]
 failing_sample = {
     'sample_id': 'sample1',
     'expected_yield_q30': 95,
-    'pc_mapped_reads': 97.18,
     'provided_gender': 'female',
-    'clean_yield_in_gb': 114.31,
     'called_gender': 'male',
     'genotype_validation': {'mismatching_snps': 3, 'no_call_chip': 1, 'no_call_seq': 0, 'matching_snps': 28},
-    'pc_duplicate_reads': 16.20,
     'coverage': {'mean': 30.156},
-    'clean_yield_q30': 89.33
+    'aggregated': {
+        'pc_mapped_reads': 97.18,
+        'clean_yield_in_gb': 114.31,
+        'pc_duplicate_reads': 16.20,
+        'clean_yield_q30': 89.33
+    }
 }
 
 passing_sample = {
@@ -36,37 +86,70 @@ passing_sample = {
     'species_name': 'Homo sapiens',
     'genotype_validation': {'mismatching_snps': 1, 'no_call_seq': 0, 'no_call_chip': 3, 'matching_snps': 28},
     'provided_gender': 'female',
-    'clean_yield_in_gb': 120.17,
-    'clean_yield_q30': 95.82,
     'called_gender': 'female',
     'coverage': {'mean': 30.34},
-    'pc_mapped_reads': 95.62,
-    'pc_duplicate_reads': 20
+    'aggregated': {
+        'clean_yield_in_gb': 120.17,
+        'clean_yield_q30': 95.82,
+        'pc_mapped_reads': 95.62,
+        'pc_duplicate_reads': 20
+    }
 }
 
 sample_no_genotype = {
     'sample_id': 'sample1',
     'species_name': 'Homo sapiens',
     'expected_yield_q30': 95,
-    # 'genotype_validation': None,
     'provided_gender': 'female',
-    'clean_yield_in_gb': 120.17,
-    'clean_yield_q30': 95.82,
     'called_gender': 'female',
     'median_coverage': 30.34,
-    'pc_mapped_reads': 95.62,
-    'pc_duplicate_reads': 20
+    'aggregated': {
+        'pc_mapped_reads': 95.62,
+        'pc_duplicate_reads': 20,
+        'clean_yield_in_gb': 120.17,
+        'clean_yield_q30': 95.82
+    }
 }
 
 non_human_sample = {
     'sample_id': 'sample1',
     'species_name': 'Bos torus',
-    'clean_yield_in_gb': 120.17,
-    'clean_yield_q30': 95.82,
     'median_coverage': 30.34,
-    'pc_mapped_reads': 95.62,
-    'pc_duplicate_reads': 20
+    'aggregated': {
+        'clean_yield_in_gb': 120.17,
+        'clean_yield_q30': 95.82,
+        'pc_mapped_reads': 95.62,
+        'pc_duplicate_reads': 20
+    }
 }
+
+
+class TestRunReviewer(TestBase):
+
+    def setUp(self):
+        self.init_request = Mock(form={'run_id': 'run1'})
+        with patch(ppath + 'eve_get', return_value=[passing_lane]):
+            self.reviewer1 = ar.AutomaticRunReviewer(self.init_request)
+            self.reviewer2 = ar.AutomaticRunReviewer(self.init_request)
+
+    def test_reviewable_data(self):
+        with patch(ppath + 'eve_get', return_value=(failing_runs[0],)) as patch_get:
+            assert self.reviewer1.reviewable_data == failing_runs[0]
+            patch_get.assert_called_once_with(
+                'runs', request_args={'where': '{"run_id": "run1"}'}
+            )
+
+    def test_perform_action(self):
+        with patch.object(AutomaticRunReviewer, 'reviewable_data', return_value=PropertyMock(return_value=failing_runs[0])), patch.object(AutomaticRunReviewer, 'run_elements', return_value=PropertyMock(return_value=failing_runs[0])) as patch_get:
+                self.reviewer1._perform_action()
+
+
+    def test_summary(self):
+        pass
+
+    @patch(ppath + 'patch_internal')
+    def test_push_review(self, mocked_patch):
+        pass
 
 
 class TestLaneReviewer(TestBase):
@@ -76,9 +159,10 @@ class TestLaneReviewer(TestBase):
         self.failing_reviewer_2 = ar.AutomaticLaneReviewer(failing_lanes[1])
 
     def test_failing_metrics(self):
-        assert self.passing_reviewer.get_failing_metrics() == []
-        assert self.failing_reviewer_1.get_failing_metrics() == ['lane_pc_optical_dups', 'yield_in_gb']
-        assert self.failing_reviewer_2.get_failing_metrics() == ['pc_q30', 'yield_in_gb']
+        assert self.passing_reviewer.failing_metrics() == []
+        assert self.failing_reviewer_1.failing_metrics() == ['aggregated.pc_opt_duplicate_reads',
+                                                                 'aggregated.yield_in_gb']
+        assert self.failing_reviewer_2.failing_metrics() == ['aggregated.pc_q30', 'aggregated.yield_in_gb']
 
     @patch(ppath + 'AutomaticLaneReviewer.get_failing_metrics', return_value=[])
     def test_summary_pass(self, mocked_get_failing_metrics):
@@ -91,7 +175,7 @@ class TestLaneReviewer(TestBase):
         assert 'review_date' in self.passing_reviewer._summary
         assert self.passing_reviewer._summary['review_comments'] == 'failed due to some, failing, metrics'
 
-    @patch(ppath + 'get', return_value=({'data': run_elements}, None, 'an_etag', 200, 'headers'))
+    @patch(ppath + 'eve_get', return_value=({'data': run_elements}, None, 'an_etag', 200, 'headers'))
     @patch(ppath + 'patch_internal')
     def test_push_review(self, mocked_patch, mocked_get):
         self.passing_reviewer.push_review()
@@ -129,36 +213,35 @@ class TestSampleReviewer(TestBase):
         self.reviewer1 = ar.AutomaticSampleReviewer(self.init_request)
 
     def test_reviewable_data(self):
-        with patch(ppath + '_aggregate', return_value=(passing_sample,)) as patch_aggregate, \
+        with patch(ppath + 'eve_get', return_value=(passing_sample,)) as patch_get, \
              self.patch_lims_samples:
             _ = self.reviewer.reviewable_data
-            patch_aggregate.assert_called_once_with(
-                'samples', queries.sample, request_args={'match': '{"sample_id": "sample1"}'}
+            patch_get.assert_called_once_with(
+                'samples', request_args={'where': '{"sample_id": "sample1"}'}
             )
 
     def test_failing_metrics(self):
-        with patch(ppath + '_aggregate', return_value=(passing_sample,)), self.patch_lims_samples:
-            assert self.reviewer.get_failing_metrics() == []
+        with patch(ppath + 'eve_get', return_value=(passing_sample,)), self.patch_lims_samples:
+            assert self.reviewer.failing_metrics() == []
 
-        with patch(ppath + '_aggregate', return_value=(failing_sample,)), self.patch_lims_samples:
-            assert self.reviewer1.get_failing_metrics() == ['clean_yield_in_gb', 'clean_yield_q30']
+        with patch(ppath + 'eve_get', return_value=(failing_sample,)), self.patch_lims_samples:
+            assert self.reviewer1.failing_metrics() == ['aggregated.clean_yield_in_gb', 'aggregated.clean_yield_q30']
 
     def test_cfg(self):
-        with patch(ppath + '_aggregate', return_value=(sample_no_genotype,)), self.patch_lims_samples:
-
+        with patch(ppath + 'eve_get', return_value=(sample_no_genotype,)), self.patch_lims_samples:
             assert 'genotype_validation.no_call_seq' not in self.reviewer.cfg
             assert 'genotype_validation.mismatching_snps' not in self.reviewer.cfg
-            assert self.reviewer.cfg['clean_yield_in_gb']['value'] == 120
+            assert self.reviewer.cfg['aggregated.clean_yield_in_gb']['value'] == 120
             assert self.reviewer.cfg['coverage.mean']['value'] == 30
 
-        with patch(ppath + '_aggregate', return_value=(passing_sample,)), self.patch_lims_samples:
+        with patch(ppath + 'eve_get', return_value=(passing_sample,)), self.patch_lims_samples:
             assert 'genotype_validation.no_call_seq' in self.reviewer1.cfg
             assert 'genotype_validation.mismatching_snps' in self.reviewer1.cfg
-            assert self.reviewer1.cfg['clean_yield_in_gb']['value'] == 120
+            assert self.reviewer1.cfg['aggregated.clean_yield_in_gb']['value'] == 120
             assert self.reviewer1.cfg['coverage.mean']['value'] == 30
 
     def test_summary(self):
-        with patch(ppath + '_aggregate', return_value=(failing_sample,)), self.patch_lims_samples:
+        with patch(ppath + 'eve_get', return_value=(failing_sample,)), self.patch_lims_samples:
             assert self.reviewer._summary == {
                 'reviewed': 'fail',
                 'review_comments': 'failed due to Yield, Yield Q30',
@@ -167,7 +250,7 @@ class TestSampleReviewer(TestBase):
 
     @patch(ppath + 'patch_internal')
     def test_push_review(self, mocked_patch):
-        with patch(ppath + '_aggregate', return_value=(passing_sample,)), self.patch_lims_samples:
+        with patch(ppath + 'eve_get', return_value=(passing_sample,)), self.patch_lims_samples:
             self.reviewer.push_review()
 
             mocked_patch.assert_called_with(

--- a/tests/test_rest_api/test_action/test_automatic_review.py
+++ b/tests/test_rest_api/test_action/test_automatic_review.py
@@ -1,4 +1,8 @@
 from unittest.mock import patch, Mock, PropertyMock
+
+import pytest
+import werkzeug
+
 from rest_api.actions import automatic_review as ar, AutomaticRunReviewer
 from rest_api.actions.automatic_review import AutomaticSampleReviewer, AutomaticLaneReviewer
 from tests.test_rest_api import TestBase
@@ -150,6 +154,11 @@ class TestRunReviewer(TestBase):
                     payload={'review_date': self.reviewer1.current_time, 'review_comments': 'failed due to Run PC Q30', 'reviewed': 'fail'}
                 )
 
+    def test_unknown_run(self):
+        with patch.object(AutomaticLaneReviewer, 'eve_get', return_value=[]):
+            with pytest.raises(werkzeug.exceptions.NotFound):
+                _ = AutomaticRunReviewer(Mock(form={'run_id': 'unknown_run'}))
+
 
 class TestLaneReviewer(TestBase):
     def setUp(self):
@@ -252,3 +261,9 @@ class TestSampleReviewer(TestBase):
                 payload={'reviewed': 'pass', 'review_comments': 'pass', 'review_date': self.reviewer.current_time},
                 sample_id='sample1'
             )
+
+    def test_unknown_sample(self):
+        with patch.object(AutomaticSampleReviewer, 'eve_get', return_value=[]):
+            with pytest.raises(werkzeug.exceptions.NotFound):
+                reviewer = AutomaticSampleReviewer(Mock(form={'sample_id': 'unknown_sample'}))
+                reviewer.reviewable_data


### PR DESCRIPTION
This PR will:
 - new metric type that allow to pass a simple mathematical formula containing metric names
 - add new metrics to assess the lanes: fixes #183
 - add run assessment:  fixes #164 
 - add detail to the comments so the threshold used is explicitly stated
 - replace the use of the aggregate endpoints with the eve provided end points using the internal eve query systems.
- ensure that queries with unknown sample/run return 404: fixes #158 
- remove unused `agreewith` comparison
