### PR TITLE
Check data source

### DIFF
--- a/bin/retrigger_aggregation.py
+++ b/bin/retrigger_aggregation.py
@@ -44,5 +44,16 @@ def retrigger_aggregation_projects(communicator, **params):
         communicator.patch_entry('projects', {}, 'project_id', p['project_id'])
 
 
+def retrigger_aggregation_samples(communicator, **params):
+    all_samples= communicator.get_documents('samples', all_pages=True, **params)
+    app_logger.info('%s samples to process', len(all_samples))
+    count = 0
+    for s in all_samples:
+        count += 1
+        if count % 100 == 0:
+            app_logger.info('%s samples processed', count)
+        communicator.patch_entry('samples', {}, 'sample_id', s['sample_id'])
+
+
 if __name__ == '__main__':
     main()

--- a/database_versioning/v0.18_to_v0.19.py
+++ b/database_versioning/v0.18_to_v0.19.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import argparse
+from egcg_core.app_logging import logging_default as log_cfg
+from egcg_core.exceptions import ConfigError
+from egcg_core.rest_communication import Communicator
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from config import reporting_app_config as app_cfg
+from bin.retrigger_aggregation import retrigger_aggregation_samples
+
+if __name__ == '__main__':
+
+    log_cfg.add_stdout_handler()
+    app_logger = log_cfg.get_logger('migration_v0.18_v0.19')
+
+    a = argparse.ArgumentParser()
+    a.add_argument('--username', required=True)
+    a.add_argument('--password', required=True)
+    args = a.parse_args()
+
+    # check the config is set
+    if not app_cfg or 'rest_api' not in app_cfg:
+        raise ConfigError('Configuration file was not set or is missing values')
+
+    app_logger.info('Retrigger aggregation')
+    c = Communicator(auth=(args.username, args.password), baseurl=app_cfg['rest_api'])
+    retrigger_aggregation_samples(c)
+
+

--- a/reporting_app/__init__.py
+++ b/reporting_app/__init__.py
@@ -240,7 +240,7 @@ def report_samples(view_type):
     if view_type == 'all':
         title = 'All samples'
         ajax_call['api_urls'] = [
-            util.construct_url('samples', max_results=10000),
+            util.construct_url('samples', max_results=15000),
             util.construct_url('lims/sample_status', match={'project_status': 'all'}),
             util.construct_url('lims/sample_info', match={'project_status': 'all'})
         ]
@@ -270,7 +270,8 @@ def report_samples(view_type):
             title,
             'samples',
             ajax_call=ajax_call,
-            review={'entity_field': 'sample_id', 'button_name': 'samplereview'}
+            review={'entity_field': 'sample_id', 'button_name': 'samplereview'},
+            create_row='color_data_source'
         )
     )
 
@@ -359,7 +360,8 @@ def report_project(project_ids):
                     'merge_on': 'sample_id'
                 },
                 fixed_header=True,
-                review={'entity_field': 'sample_id', 'button_name': 'samplereview'}
+                review={'entity_field': 'sample_id', 'button_name': 'samplereview'},
+                create_row='color_data_source'
             )
         ],
         procs=procs
@@ -387,7 +389,8 @@ def report_sample(sample_id):
                     ]
                 },
                 minimal=True,
-                review={'entity_field': 'sample_id', 'button_name': 'samplereview'}
+                review={'entity_field': 'sample_id', 'button_name': 'samplereview'},
+                create_row='color_data_source'
             ),
             util.datatable_cfg(
                 'Run elements generated for ' + sample_id,

--- a/reporting_app/static/datatable.js
+++ b/reporting_app/static/datatable.js
@@ -106,6 +106,23 @@ var color_filter = function( row, data, dataIndex ) {
     }
 }
 
+var color_data_source = function( row, data, dataIndex ) {
+    if (
+        _.has(data, 'aggregated.most_recent_proc.data_source')
+        && _.has(data, 'aggregated.from_run_elements.useable_run_elements')
+    ) {
+        var list1 = _.get(data, 'aggregated.from_run_elements.useable_run_elements');
+        var list2 = _.get(data, 'aggregated.most_recent_proc.data_source');
+        list1.sort()
+        list2.sort()
+        console.log(list1)
+        console.log(list2)
+        if (!_.isEqual(list1, list2)){
+            $(row).addClass('data-source-error');
+        }
+    }
+}
+
 
 var lims_run_review = function(dt_config) {
     return _lims_review(

--- a/reporting_app/static/datatable.js
+++ b/reporting_app/static/datatable.js
@@ -115,8 +115,6 @@ var color_data_source = function( row, data, dataIndex ) {
         var list2 = _.get(data, 'aggregated.most_recent_proc.data_source');
         list1.sort()
         list2.sort()
-        console.log(list1)
-        console.log(list2)
         if (!_.isEqual(list1, list2)){
             $(row).addClass('data-source-error');
         }

--- a/reporting_app/static/stylesheets/reporting_app.css
+++ b/reporting_app/static/stylesheets/reporting_app.css
@@ -61,6 +61,10 @@
     background-color: #fcf8e3;
 }
 
+.data-source-error {
+    background-color: #f78a7e;
+}
+
 .overlay {
     display: none;
     position: absolute;

--- a/rest_api/aggregation/database_hooks.py
+++ b/rest_api/aggregation/database_hooks.py
@@ -341,6 +341,7 @@ class Sample(DataRelation):
         },
         {
             'from_run_elements': {
+                'useable_run_elements': ToSet('run_elements.run_element_id'),
                 'mean_coverage': Total('run_elements.coverage.mean'),
                 'bam_file_reads': Total('run_elements.mapping_metrics.bam_file_reads'),
                 'mapped_reads': Total('run_elements.mapping_metrics.mapped_reads'),

--- a/tests/test_reporting_app.py
+++ b/tests/test_reporting_app.py
@@ -264,12 +264,13 @@ class TestReportingApp(Helper):
                 'func_name': 'merge_multi_sources_keep_first',
                 'merge_on': 'sample_id',
                 'api_urls': [
-                    '/api/0.1/samples?max_results=10000',
+                    '/api/0.1/samples?max_results=15000',
                     '/api/0.1/lims/sample_status?match={"project_status":"all"}',
                     '/api/0.1/lims/sample_info?match={"project_status":"all"}'
                 ]
             },
-            review={'entity_field': 'sample_id', 'button_name': 'samplereview'}
+            review={'entity_field': 'sample_id', 'button_name': 'samplereview'},
+            create_row='color_data_source'
         )
 
         mocked_render = self._test_render_template('/samples/toreview')
@@ -291,7 +292,8 @@ class TestReportingApp(Helper):
                     '/api/0.1/lims/sample_info?match={"createddate":"13_06_2017_00:00:00","project_status":"open"}'
                 ]
             },
-            review={'entity_field': 'sample_id', 'button_name': 'samplereview'}
+            review={'entity_field': 'sample_id', 'button_name': 'samplereview'},
+            create_row='color_data_source'
         )
 
     @patch('reporting_app.rest_api')

--- a/tests/test_rest_api/test_aggregation/test_database_hooks.py
+++ b/tests/test_rest_api/test_aggregation/test_database_hooks.py
@@ -325,6 +325,7 @@ class TestDatabaseHooks(TestCase):
             'coverage_at_15X': 66.66666666666666, 'most_recent_proc': None, 'clean_yield_in_gb': 5.000000002,
             'clean_pc_q30_r1': 92.30769231065089, 'clean_pc_q30': 92.0000000032, 'clean_yield_q30_in_gb': 4.600000002,
             'from_run_elements': {
+                'useable_run_elements': ['150724_test_1_ATGA', '150724_test_1_ATGC'],
                 'mapped_reads': 16500, 'duplicate_reads': 2100, 'bam_file_reads': 17040,
                 'pc_mapped_reads': 96.83098591549296, 'picard_opt_dup_reads': 1100,
                 'pc_duplicate_reads': 12.323943661971832, 'pc_opt_duplicate_reads': 6.455399061032864,
@@ -360,6 +361,7 @@ class TestDatabaseHooks(TestCase):
              'clean_pc_q30': 91.80327869255576, 'clean_yield_q30_in_gb': 5.600000003}
         )
         exp['from_run_elements'].update({'mean_coverage': 6.5})
+        exp['from_run_elements']['useable_run_elements'].append('150724_test_2_ATGG')
 
         self.assert_dict_subsets(exp, self.get('samples')[0]['aggregated'])
 


### PR DESCRIPTION
This PR adds:
 - A new aggregated filed in sample for the useable run elements
 - highlight of the sample in red when the aggregated useable run elements and the analysis_driver_proc.source are different
This will allow us to see where sample needs to be reprocessed when the usability of the run elements is changed