### PR TITLE
Duplicates per lane

### DIFF
--- a/bin/retrigger_aggregation.py
+++ b/bin/retrigger_aggregation.py
@@ -33,6 +33,17 @@ def retrigger_aggregation_run_elements(communicator, **params):
         communicator.patch_entries('run_elements', {}, where={'run_id': r['run_id']})
 
 
+def retrigger_aggregation_lanes(communicator, **params):
+    all_runs = communicator.get_documents('runs', all_pages=True, **params)
+    app_logger.info('%s runs to process', len(all_runs))
+    count = 0
+    for r in all_runs:
+        count += 1
+        if count % 100 == 0:
+            app_logger.info('%s runs processed', count)
+        communicator.patch_entries('lanes', {}, where={'run_id': r['run_id']})
+
+
 def retrigger_aggregation_projects(communicator, **params):
     all_projects = communicator.get_documents('projects', all_pages=True, **params)
     app_logger.info('%s project to process', len(all_projects))

--- a/database_versioning/v0.19_to_v0.20.py
+++ b/database_versioning/v0.19_to_v0.20.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import argparse
+from egcg_core.app_logging import logging_default as log_cfg
+from egcg_core.exceptions import ConfigError
+from egcg_core.rest_communication import Communicator
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from config import reporting_app_config as app_cfg
+from bin.retrigger_aggregation import retrigger_aggregation_lanes
+
+if __name__ == '__main__':
+
+    log_cfg.add_stdout_handler()
+    app_logger = log_cfg.get_logger('migration_v0.18_v0.19')
+
+    a = argparse.ArgumentParser()
+    a.add_argument('--username', required=True)
+    a.add_argument('--password', required=True)
+    args = a.parse_args()
+
+    # check the config is set
+    if not app_cfg or 'rest_api' not in app_cfg:
+        raise ConfigError('Configuration file was not set or is missing values')
+
+    app_logger.info('Retrigger aggregation')
+    c = Communicator(auth=(args.username, args.password), baseurl=app_cfg['rest_api'])
+    retrigger_aggregation_lanes(c)
+
+

--- a/etc/review_thresholds.yaml
+++ b/etc/review_thresholds.yaml
@@ -50,9 +50,9 @@ lane:
         value: 30
         comparison: '<'
     compound_yield_adapter_duplicates:
-        formula: 'aggregated.yield_in_gb * (100 - aggregated.pc_adaptor)/100 * (100 - aggregated.pc_opt_duplicate_reads)/100'
+        formula: 'aggregated.yield_in_gb * (100 - aggregated.pc_adaptor)/100 * (100 - aggregated.pc_duplicate_reads)/100'
         name: Yield with no adapters and no duplicates
-        value: 95
+        value: 96    # This is the amount of data required for 30X human genome
         comparison: '>'
 
 

--- a/rest_api/aggregation/database_hooks.py
+++ b/rest_api/aggregation/database_hooks.py
@@ -285,7 +285,10 @@ class Lane(DataRelation):
                 Add('aggregated.bases_r1', 'aggregated.bases_r2')
             ),
             'lane_pc_optical_dups': FirstElement('run_elements.lane_pc_optical_dups'),  # TODO: fix this in the schema
-            'pc_duplicate_reads': Percentage('mapping_metrics.duplicate_reads', 'mapping_metrics.bam_file_reads'),
+            'pc_duplicate_reads': Percentage(
+                Total('run_elements.mapping_metrics.duplicate_reads'),
+                Total('run_elements.mapping_metrics.bam_file_reads')
+            ),
             'pc_opt_duplicate_reads': Percentage(
                 Total('run_elements.mapping_metrics.picard_opt_dup_reads'),
                 Total('run_elements.mapping_metrics.bam_file_reads')

--- a/tests/test_rest_api/test_action/test_automatic_review.py
+++ b/tests/test_rest_api/test_action/test_automatic_review.py
@@ -18,6 +18,7 @@ passing_lane = {
         'pc_q30': 83.01,
         'pc_q30_r1': 89.21,
         'pc_q30_r2': 78.14,
+        'pc_duplicate_reads': 22.1,
         'pc_opt_duplicate_reads': 21.1,
         'pc_adaptor': 0.5
     }
@@ -33,6 +34,7 @@ failing_lanes = [
             'pc_q30_r2': 74.9,
             'pc_pass_filter': 39.87,
             'yield_in_gb': 74.30,
+            'pc_duplicate_reads': 31.5,
             'pc_opt_duplicate_reads': 30.1,
             'pc_adaptor': 2.3
         }
@@ -46,6 +48,7 @@ failing_lanes = [
             'pc_q30_r2': 71.2,
             'pc_pass_filter': 40.17,
             'yield_in_gb': 74.86,
+            'pc_duplicate_reads': 22.9,
             'pc_opt_duplicate_reads': 21.1,
             'pc_adaptor': 0.3
         }
@@ -60,7 +63,8 @@ failing_runs = [
             'pc_q30_r1': 76.1,
             'pc_q30_r2': 70.6,
             "yield_in_gb": 1096.2,
-            "pc_opt_duplicate_reads": 22.59,
+            "pc_duplicate_reads": 22.59,
+            'pc_opt_duplicate_reads': 21.1,
             'pc_adaptor': 1.3
         }
     },
@@ -69,7 +73,8 @@ failing_runs = [
         'aggregated': {
             'pc_q30': 81.5,
             "yield_in_gb": 920.12,
-            "pc_opt_duplicate_reads": 30.59,
+            "pc_duplicate_reads": 30.59,
+            'pc_opt_duplicate_reads': 21.1,
             'pc_adaptor': 0.8
         }
     }
@@ -244,11 +249,11 @@ class TestLaneReviewer(TestBase):
         assert self.failing_reviewer_1._summary['reviewed'] == 'fail'
         assert 'review_date' in self.failing_reviewer_1._summary
         assert self.failing_reviewer_1._summary['review_comments'] == \
-               'Failed due to Optical duplicate rate > 30, Yield < 120, Yield with no adapters and no duplicates < 95'
+               'Failed due to Optical duplicate rate > 30, Yield < 120, Yield with no adapters and no duplicates < 96'
 
     def test_get_failure_comment(self):
         assert self.failing_reviewer_1.failure_comment == \
-               'Failed due to Optical duplicate rate > 30, Yield < 120, Yield with no adapters and no duplicates < 95'
+               'Failed due to Optical duplicate rate > 30, Yield < 120, Yield with no adapters and no duplicates < 96'
 
     @patch.object(AutomaticLaneReviewer, 'eve_get', return_value=run_elements)
     @patch(ppath + 'patch_internal')


### PR DESCRIPTION
This PR fixes the duplicate rate of a lane that was calculated incorrectly.
It also changes the threshold and formula used for the compound criteria in Automatic Run review.

closes #194 
