### PR TITLE
Remove automatic run review so only perform lane review.

### DIFF
--- a/etc/review_thresholds.yaml
+++ b/etc/review_thresholds.yaml
@@ -6,23 +6,7 @@
 #  * [optional] a formula that replace the metric key as the source of the data.
 #    formula can have numeric or existing metric name
 
-run:
-    aggregated.yield_in_gb:
-        name: Run Yield
-        value: 960
-        comparison: '>'
-    aggregated.pc_q30:
-        name: Run PC Q30
-        value: 75
-        comparison: '>'
-    aggregated.pc_q30_r1:
-        name: Run PC Q30 R1
-        value: 70
-        comparison: '>'
-    aggregated.pc_q30_r2:
-        name: Run PC Q30 R2
-        value: 70
-        comparison: '>'
+
 
 lane:
     aggregated.yield_in_gb:

--- a/rest_api/actions/automatic_review.py
+++ b/rest_api/actions/automatic_review.py
@@ -144,7 +144,7 @@ class AutomaticLaneReviewer(AutomaticReviewer):
                 )
 
 
-class AutomaticRunReviewer(Action, AutomaticLaneReviewer):
+class AutomaticRunReviewer(Action, AutomaticReviewer):
     def __init__(self, request):
         super().__init__(request)
         self.run_id = self.request.form.get('run_id')
@@ -154,29 +154,9 @@ class AutomaticRunReviewer(Action, AutomaticLaneReviewer):
             abort(404, 'No data found for run id %s.' % self.run_id)
         self.lane_reviewers = [AutomaticLaneReviewer(lane) for lane in lanes]
 
-    @property
-    def run_elements(self):
-        return self.eve_get('run_elements', run_id=self.run_id)
-
-    @property
-    def cfg(self):
-        return review_thresholds['run']
-
-    @cached_property
-    def reviewable_data(self):
-        data = self.eve_get('runs', run_id=self.run_id)
-        if data:
-            return data[0]
-        else:
-            abort(404, 'No data found for run id %s.' % self.run_id)
-
     def _perform_action(self):
-        # Test the run first and only test the lanes if the run pass
-        if self.failing_metrics:
-            self.push_review()
-        else:
-            for reviewer in self.lane_reviewers:
-                reviewer.push_review()
+        for reviewer in self.lane_reviewers:
+            reviewer.push_review()
         return {
             'action_id': self.run_id + self.date_started,
             'date_finished': self.now(),

--- a/tests/test_rest_api/test_action/test_automatic_review.py
+++ b/tests/test_rest_api/test_action/test_automatic_review.py
@@ -2,9 +2,8 @@ from unittest.mock import patch, Mock, PropertyMock
 
 import pytest
 import werkzeug
-from rest_api import app
 from rest_api.actions import automatic_review as ar, AutomaticRunReviewer
-from rest_api.actions.automatic_review import AutomaticSampleReviewer, AutomaticLaneReviewer
+from rest_api.actions.automatic_review import AutomaticSampleReviewer, AutomaticLaneReviewer, AutomaticReviewer
 from tests.test_rest_api import TestBase
 
 ppath = 'rest_api.actions.automatic_review.'
@@ -51,31 +50,6 @@ failing_lanes = [
             'pc_duplicate_reads': 22.9,
             'pc_opt_duplicate_reads': 21.1,
             'pc_adaptor': 0.3
-        }
-    }
-]
-
-failing_runs = [
-    {
-        'run_id': 'run1',
-        'aggregated': {
-            'pc_q30': 73.4,
-            'pc_q30_r1': 76.1,
-            'pc_q30_r2': 70.6,
-            "yield_in_gb": 1096.2,
-            "pc_duplicate_reads": 22.59,
-            'pc_opt_duplicate_reads': 21.1,
-            'pc_adaptor': 1.3
-        }
-    },
-    {
-        'run_id': 'run2',
-        'aggregated': {
-            'pc_q30': 81.5,
-            "yield_in_gb": 920.12,
-            "pc_duplicate_reads": 30.59,
-            'pc_opt_duplicate_reads': 21.1,
-            'pc_adaptor': 0.8
         }
     }
 ]
@@ -169,48 +143,30 @@ class TestRunReviewer(TestBase):
 
     def setUp(self):
         self.init_request = Mock(form={'run_id': 'run1'})
-        with patch.object(AutomaticLaneReviewer, 'eve_get', return_value=[passing_lane]):
+        with patch.object(AutomaticReviewer, 'eve_get', return_value=failing_lanes):
             self.reviewer1 = ar.AutomaticRunReviewer(self.init_request)
 
-    def test_eve_get(self):
-        page1 = {'data': ['test1'], '_links': {'next': {'href': 'endpoint?page=2'}}}
-        page2 = {'data': ['test2'], '_links': {'next': {'href': 'endpoint?page=3'}}}
-        page3 = {'data': ['test3'], '_links': {}}
-
-        with patch('rest_api.actions.automatic_review.get', side_effect=[(page1,), (page2,), (page3,)]) as mock_get:
-            with app.test_request_context():
-                assert self.reviewer1.eve_get('endpoint', param1='this') == ['test1', 'test2', 'test3']
-                mock_get.call_count == 3
-                mock_get.assert_called_with('endpoint', param1='this')
-
-    def test_reviewable_data(self):
-        with patch.object(AutomaticLaneReviewer, 'eve_get', return_value=(failing_runs[0],)) as patch_get:
-            assert self.reviewer1.reviewable_data == failing_runs[0]
-            patch_get.assert_called_once_with('runs', run_id='run1')
-
     def test_perform_action(self):
-        with patch.object(AutomaticRunReviewer, 'reviewable_data', new_callable=PropertyMock(return_value=failing_runs[0])), \
-             patch.object(AutomaticRunReviewer, 'run_elements', new_callable=PropertyMock(return_value=run_elements)), \
+        with patch.object(AutomaticLaneReviewer, 'run_elements', new_callable=PropertyMock(return_value=run_elements)), \
              patch(ppath + 'patch_internal') as mocked_patch:
                 self.reviewer1._perform_action()
-                mocked_patch.assert_any_call(
-                    'run_elements', lane=1, run_id='run1', barcode='b1',
-                    payload={
-                        'review_date': self.reviewer1.current_time,
-                        'review_comments': 'Failed due to Run PC Q30 < 75',
-                        'reviewed': 'fail'
-                    }
-                )
-                mocked_patch.assert_called_with(
-                    'run_elements', lane=1, run_id='run1', barcode='b2',
-                    payload={
-                        'review_date': self.reviewer1.current_time,
-                        'review_comments': 'Failed due to Run PC Q30 < 75',
-                        'reviewed': 'fail'}
-                )
+                payload1 = {
+                    'review_date': self.reviewer1.current_time,
+                    'review_comments': 'Failed due to Optical duplicate rate > 30, Yield < 120, Yield with no adapters and no duplicates < 96',
+                    'reviewed': 'fail'
+                }
+                payload2 = {
+                    'review_date': self.reviewer1.current_time,
+                    'review_comments': 'Failed due to PC Q30 < 75, Yield < 120, Yield with no adapters and no duplicates < 96',
+                    'reviewed': 'fail'
+                }
+                mocked_patch.assert_any_call('run_elements', lane=1, run_id='a_run', barcode='b1', payload=payload1)
+                mocked_patch.assert_any_call('run_elements', lane=1, run_id='a_run', barcode='b2', payload=payload1)
+                mocked_patch.assert_any_call('run_elements', lane=1, run_id='a_run', barcode='b1', payload=payload2)
+                mocked_patch.assert_any_call('run_elements', lane=1, run_id='a_run', barcode='b2', payload=payload2)
 
     def test_unknown_run(self):
-        with patch.object(AutomaticLaneReviewer, 'eve_get', return_value=[]):
+        with patch.object(AutomaticReviewer, 'eve_get', return_value=[]):
             with pytest.raises(werkzeug.exceptions.NotFound):
                 _ = AutomaticRunReviewer(Mock(form={'run_id': 'unknown_run'}))
 

--- a/tests/test_rest_api/test_action/test_automatic_review.py
+++ b/tests/test_rest_api/test_action/test_automatic_review.py
@@ -2,6 +2,7 @@ from unittest.mock import patch, Mock, PropertyMock
 
 import pytest
 import werkzeug
+from rest_api import app
 from rest_api.actions import automatic_review as ar, AutomaticRunReviewer
 from rest_api.actions.automatic_review import AutomaticSampleReviewer, AutomaticLaneReviewer, AutomaticReviewer
 from tests.test_rest_api import TestBase
@@ -137,6 +138,21 @@ non_human_sample = {
         'pc_duplicate_reads': 20
     }
 }
+
+
+class TestAutomaticReview(TestBase):
+
+    def test_eve_get(self):
+        reviewer = ar.AutomaticReviewer()
+        page1 = {'data': ['test1'], '_links': {'next': {'href': 'endpoint?page=2'}}}
+        page2 = {'data': ['test2'], '_links': {'next': {'href': 'endpoint?page=3'}}}
+        page3 = {'data': ['test3'], '_links': {}}
+
+        with patch('rest_api.actions.automatic_review.get', side_effect=[(page1,), (page2,), (page3,)]) as mock_get:
+            with app.test_request_context():
+                assert reviewer.eve_get('endpoint', param1='this') == ['test1', 'test2', 'test3']
+                mock_get.call_count == 3
+                mock_get.assert_called_with('endpoint', param1='this')
 
 
 class TestRunReviewer(TestBase):

--- a/tests/test_rest_api/test_action/test_review.py
+++ b/tests/test_rest_api/test_action/test_review.py
@@ -62,7 +62,7 @@ class TestReviewInitiator(TestBase):
         global _cache_samples
         _cache_samples = {}
 
-    @patch('egcg_core.clarity.connection', return_value=MagicMock(spec=Lims, cache={}))
+    @patch('rest_api.actions.reviews.clarity.connection', return_value=MagicMock(spec=Lims, cache={}))
     def test_lims(self, mocked_connection):
         assert self.initiator.lims
         # Check that the Lims was found
@@ -78,7 +78,7 @@ class TestReviewInitiator(TestBase):
         assert e.exception.code == 401
         assert e.exception.description == 'Authentication in the LIMS (http://clarity.com) failed'
 
-    @patch('egcg_core.clarity.get_list_of_samples', side_effect=SideEffectWithMemory(fake_get_list_samples))
+    @patch('rest_api.actions.reviews.clarity.get_list_of_samples', side_effect=SideEffectWithMemory(fake_get_list_samples))
     def test_samples_to_review(self, mocked_get_list_of_samples):
         assert self.initiator.samples_to_review[0].name == 'sample_1'
 


### PR DESCRIPTION
This PR removes the review of a whole run when performing the AutomaticRunReview.
The lane review is left unchanged
closes #210   