### PR TITLE
Remove samples from Invoicing column when they are in removed status

### DIFF
--- a/rest_api/limsdb/queries/data_models.py
+++ b/rest_api/limsdb/queries/data_models.py
@@ -153,7 +153,9 @@ class Sample(SampleInfo):
         for process, date, process_type, process_id in self.processes:
             if process_type == 'complete' and process in status_cfg.additional_step_completed:
                 finished_status = status_cfg.additional_step_completed.get(process)
-                additional_status.add(finished_status)
+                # A sample should not appear in invoiced if it has been removed, as this is paradoxical
+                if self.status != 'removed' or finished_status == 'genotyped':
+                    additional_status.add(finished_status)
         return additional_status
 
     @property

--- a/rest_api/limsdb/queries/data_models.py
+++ b/rest_api/limsdb/queries/data_models.py
@@ -154,7 +154,7 @@ class Sample(SampleInfo):
             if process_type == 'complete' and process in status_cfg.additional_step_completed:
                 finished_status = status_cfg.additional_step_completed.get(process)
                 # A sample should not appear in invoiced if it has been removed, as this is paradoxical
-                if self.status != 'removed' or finished_status == 'genotyped':
+                if self.status != 'removed' or finished_status != 'invoiced':
                     additional_status.add(finished_status)
         return additional_status
 


### PR DESCRIPTION
Samples which show up as removed no longer appear in invoiced as well, as this is deemed paradoxical.

closes #160 